### PR TITLE
Rename and document protocol serialization extensions

### DIFF
--- a/src/McProtoNet.Protocol/AGENTS.MD
+++ b/src/McProtoNet.Protocol/AGENTS.MD
@@ -88,6 +88,29 @@ These values define the **absolute supported protocol range**.
 
 ---
 
+## 6.1 Protocol Serialization Extension Layer
+
+McProtoNet.Protocol defines protocol-level serialization primitives as
+extension methods on:
+
+* `MinecraftPrimitiveReader`
+* `MinecraftPrimitiveWriter`
+
+These live in `Extensions/ProtocolSerializationExtensions*.cs` under the
+`McProtoNet.Protocol.Extensions` namespace.
+
+Rules:
+
+* Extension methods here implement **primitive protocol serialization** only.
+* Generic helpers like `WriteType<T>` are **extension points**, not implementations.
+* Data types MUST remain semantic and version-agnostic; they must not contain
+  serialization logic beyond invoking these extensions in `Read*`/`Write*`.
+* Packets orchestrate serialization by calling `Read*`/`Write*` methods, not by
+  embedding primitive serialization logic directly.
+* Agents MUST NOT add reflection-based or generic serializers to this layer.
+
+---
+
 ## 7. Packets vs Data Types (CRITICAL)
 
 ### Packets
@@ -274,5 +297,4 @@ The agent MUST:
 
 > When in doubt, STOP.
 > Incorrect code generation is worse than no code generation.
-
 

--- a/src/McProtoNet.Protocol/Extensions/ProtocolSerializationExtensions.Nbt.cs
+++ b/src/McProtoNet.Protocol/Extensions/ProtocolSerializationExtensions.Nbt.cs
@@ -7,7 +7,7 @@ public struct VarInt;
 public struct VarLong;
 
 
-public static class TypeExtensions
+public static partial class ProtocolSerializationExtensions
 {
     public static NbtTag? ReadNbtTag(this ref MinecraftPrimitiveReader reader, int protocolVersion)
     {

--- a/src/McProtoNet.Protocol/Extensions/ProtocolSerializationExtensions.cs
+++ b/src/McProtoNet.Protocol/Extensions/ProtocolSerializationExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace McProtoNet.Protocol.Extensions;
 
-public static class GenericExtensions
+public static partial class ProtocolSerializationExtensions
 {
     extension(ref MinecraftPrimitiveWriter writer)
     {


### PR DESCRIPTION
### Motivation

- Clarify the intent and responsibility boundary of the serialization extension layer by giving it an intention-revealing name.  
- Distinguish protocol-level primitive serialization from data type semantics and generated code responsibilities.  
- Make the extension surface easier to discover and maintain by consolidating related helpers under a single partial type.  
- Provide explicit guidance to agents about what belongs in the serialization extensions vs. data types in `AGENTS.md`.

### Description

- Renamed `GenericExtensions.cs` to `ProtocolSerializationExtensions.cs` and `ArrayExtensions.cs` to `ProtocolSerializationExtensions.Nbt.cs` and updated the declared types accordingly.  
- Replaced the previous `GenericExtensions` and `TypeExtensions` classes with a single partial class `ProtocolSerializationExtensions` in the `McProtoNet.Protocol.Extensions` namespace.  
- Added a new `## 6.1 Protocol Serialization Extension Layer` section to `src/McProtoNet.Protocol/AGENTS.MD` documenting that primitive serialization extensions live on `MinecraftPrimitiveReader`/`MinecraftPrimitiveWriter`, their file location, and rules for agent behavior.  
- No runtime serialization logic was changed; the edits are purely naming/organization and documentation updates.

### Testing

- No automated tests were executed for this change.  
- A commit was created containing the renames and documentation updates.  
- No behavioral or serialization changes were introduced, so no protocol regression tests were run.  
- Further CI/compilation validation can be run separately if desired.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952aa5941b883259ddbe3da202e8620)