### PR TITLE
Implement Slot family, SlotComponent union and versioned serializers

### DIFF
--- a/src/McProtoNet.Protocol/Extensions/ProtocolSerializationExtensions.Nbt.cs
+++ b/src/McProtoNet.Protocol/Extensions/ProtocolSerializationExtensions.Nbt.cs
@@ -18,6 +18,36 @@ public static partial class ProtocolSerializationExtensions
     {
         return reader.ReadOptionalNbtTag(protocolVersion < 764);
     }
+
+    public static NbtTag? ReadAnonymousNbtTag(this ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        return reader.ReadNbtTag(readRootTag: false);
+    }
+
+    public static NbtTag? ReadAnonOptionalNbtTag(this ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        return reader.ReadOptionalNbtTag(readRootTag: false);
+    }
+
+    public static void WriteNbtTag(this ref MinecraftPrimitiveWriter writer, NbtTag value, int protocolVersion)
+    {
+        writer.WriteNbt(value);
+    }
+
+    public static void WriteOptionalNbtTag(this ref MinecraftPrimitiveWriter writer, NbtTag? value, int protocolVersion)
+    {
+        writer.WriteOptionalNbt(value);
+    }
+
+    public static void WriteAnonymousNbtTag(this ref MinecraftPrimitiveWriter writer, NbtTag value, int protocolVersion)
+    {
+        writer.WriteNbt(value);
+    }
+
+    public static void WriteAnonOptionalNbtTag(this ref MinecraftPrimitiveWriter writer, NbtTag? value, int protocolVersion)
+    {
+        writer.WriteOptionalNbt(value);
+    }
     //
     // public static Position ReadPosition(this ref MinecraftPrimitiveReader reader, int protocolVersion)
     // {

--- a/src/McProtoNet.Protocol/Extensions/ProtocolSerializationExtensions.Registry.cs
+++ b/src/McProtoNet.Protocol/Extensions/ProtocolSerializationExtensions.Registry.cs
@@ -1,0 +1,18 @@
+using McProtoNet.Serialization;
+using McProtoNet.Protocol;
+
+namespace McProtoNet.Protocol.Extensions;
+
+public static partial class ProtocolSerializationExtensions
+{
+    public static RegistryEntryHolder<T> ReadRegistryEntryHolder<T>(this ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        throw new NotImplementedException("TODO: Implement registryEntryHolder serialization in ProtocolSerializationExtensions.");
+    }
+
+    public static void WriteRegistryEntryHolder<T>(this ref MinecraftPrimitiveWriter writer, RegistryEntryHolder<T> value,
+        int protocolVersion)
+    {
+        throw new NotImplementedException("TODO: Implement registryEntryHolder serialization in ProtocolSerializationExtensions.");
+    }
+}

--- a/src/McProtoNet.Protocol/Extensions/ProtocolSerializationExtensions.cs
+++ b/src/McProtoNet.Protocol/Extensions/ProtocolSerializationExtensions.cs
@@ -68,6 +68,25 @@ public static partial class ProtocolSerializationExtensions
             writer.WriteFloat(vec.Z);
             writer.WriteFloat(vec.W);
         }
+
+        public void WritePosition(Position position, int protocolVersion)
+        {
+            ThrowHelper.ThrowIfProtocolNotSupported<Position>(protocolVersion);
+            if (protocolVersion >= 477)
+            {
+                var encoded = (((ulong)position.X & 0x3FFFFFF) << 38) |
+                              (((ulong)position.Z & 0x3FFFFFF) << 12) |
+                              ((ulong)position.Y & 0xFFF);
+                writer.WriteUnsignedLong(encoded);
+            }
+            else
+            {
+                var encoded = (((ulong)position.X & 0x3FFFFFF) << 38) |
+                              (((ulong)position.Y & 0xFFF) << 26) |
+                              ((ulong)position.Z & 0x3FFFFFF);
+                writer.WriteUnsignedLong(encoded);
+            }
+        }
     }
 
     extension(ref MinecraftPrimitiveReader reader)

--- a/src/McProtoNet.Protocol/Types/HashedSlot.cs
+++ b/src/McProtoNet.Protocol/Types/HashedSlot.cs
@@ -1,0 +1,83 @@
+using McProtoNet.Protocol.Attributes;
+using McProtoNet.Serialization;
+
+namespace McProtoNet.Protocol;
+
+[ProtocolSupport(770, MinecraftVersion.LatestProtocol)]
+public sealed partial record HashedSlot(Slot Slot, IReadOnlyList<HashedSlotComponent> Components)
+{
+    public sealed record HashedSlotComponent(SlotComponentType Type, int Hash);
+
+    public static HashedSlot Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<HashedSlot>(protocolVersion);
+        int itemId = reader.ReadVarInt();
+        int itemCount = reader.ReadVarInt();
+        HashedSlotComponent[] components = ReadComponents(ref reader, protocolVersion);
+        SlotComponentType[] removed = ReadRemovedComponents(ref reader, protocolVersion);
+        var slot = new Slot
+        {
+            ItemId = itemId,
+            ItemCount = itemCount,
+            RemovedComponents = removed
+        };
+        return new HashedSlot(slot, components);
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<HashedSlot>(protocolVersion);
+        writer.WriteVarInt(Slot.ItemId ?? 0);
+        writer.WriteVarInt(Slot.ItemCount ?? 0);
+        writer.WriteVarInt(Components.Count);
+        for (int i = 0; i < Components.Count; i++)
+        {
+            Components[i].Type.Write(ref writer, protocolVersion);
+            writer.WriteSignedInt(Components[i].Hash);
+        }
+        writer.WriteVarInt(Slot.RemovedComponents?.Count ?? 0);
+        if (Slot.RemovedComponents is not null)
+        {
+            foreach (var removed in Slot.RemovedComponents)
+            {
+                removed.Write(ref writer, protocolVersion);
+            }
+        }
+    }
+
+    private static HashedSlotComponent[] ReadComponents(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        int count = reader.ReadVarInt();
+        if (count == 0)
+        {
+            return Array.Empty<HashedSlotComponent>();
+        }
+
+        var components = new HashedSlotComponent[count];
+        for (int i = 0; i < count; i++)
+        {
+            var type = SlotComponentTypeExtensions.Read(ref reader, protocolVersion);
+            int hash = reader.ReadSignedInt();
+            components[i] = new HashedSlotComponent(type, hash);
+        }
+
+        return components;
+    }
+
+    private static SlotComponentType[] ReadRemovedComponents(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        int count = reader.ReadVarInt();
+        if (count == 0)
+        {
+            return Array.Empty<SlotComponentType>();
+        }
+
+        var components = new SlotComponentType[count];
+        for (int i = 0; i < count; i++)
+        {
+            components[i] = SlotComponentTypeExtensions.Read(ref reader, protocolVersion);
+        }
+
+        return components;
+    }
+}

--- a/src/McProtoNet.Protocol/Types/RegistryEntryHolder.cs
+++ b/src/McProtoNet.Protocol/Types/RegistryEntryHolder.cs
@@ -1,0 +1,20 @@
+using McProtoNet.Protocol.Attributes;
+using McProtoNet.Serialization;
+
+namespace McProtoNet.Protocol;
+
+[ProtocolSupport(766, MinecraftVersion.LatestProtocol)]
+public readonly partial record struct RegistryEntryHolder<T>
+{
+    public static RegistryEntryHolder<T> Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<RegistryEntryHolder<T>>(protocolVersion);
+        return reader.ReadRegistryEntryHolder<T>(protocolVersion);
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<RegistryEntryHolder<T>>(protocolVersion);
+        writer.WriteRegistryEntryHolder(this, protocolVersion);
+    }
+}

--- a/src/McProtoNet.Protocol/Types/Slot.cs
+++ b/src/McProtoNet.Protocol/Types/Slot.cs
@@ -1,22 +1,216 @@
-﻿using McProtoNet.NBT;
+using McProtoNet.NBT;
+using McProtoNet.Protocol.Attributes;
+using McProtoNet.Serialization;
 
 namespace McProtoNet.Protocol;
 
-public sealed class Slot
+[ProtocolSupport(MinecraftVersion.StartProtocol, MinecraftVersion.LatestProtocol)]
+public sealed partial class Slot
 {
-    public Slot(int itemId, sbyte itemCount, NbtTag? nbt)
-    {
-        ItemId = itemId;
-        ItemCount = itemCount;
-        Nbt = nbt;
-    }
-
-    public Slot()
-    {
-    }
-
-
-    public int ItemId { get; set; }
-    public sbyte ItemCount { get; set; }
+    public int? ItemId { get; set; }
+    public int? ItemCount { get; set; }
     public NbtTag? Nbt { get; set; }
+    public IReadOnlyList<SlotComponent>? Components { get; set; }
+    public IReadOnlyList<SlotComponentType>? RemovedComponents { get; set; }
+
+    public static Slot Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<Slot>(protocolVersion);
+        if (protocolVersion <= 763)
+        {
+            bool present = reader.ReadBoolean();
+            if (!present)
+            {
+                return new Slot();
+            }
+
+            int itemId = reader.ReadVarInt();
+            sbyte itemCount = reader.ReadSignedByte();
+            NbtTag? nbt = reader.ReadOptionalNbtTag(protocolVersion);
+            return new Slot
+            {
+                ItemId = itemId,
+                ItemCount = itemCount,
+                Nbt = nbt
+            };
+        }
+
+        if (protocolVersion <= 765)
+        {
+            bool present = reader.ReadBoolean();
+            if (!present)
+            {
+                return new Slot();
+            }
+
+            int itemId = reader.ReadVarInt();
+            sbyte itemCount = reader.ReadSignedByte();
+            NbtTag? nbt = reader.ReadAnonOptionalNbtTag(protocolVersion);
+            return new Slot
+            {
+                ItemId = itemId,
+                ItemCount = itemCount,
+                Nbt = nbt
+            };
+        }
+
+        if (protocolVersion == 766)
+        {
+            sbyte itemCount = reader.ReadSignedByte();
+            if (itemCount == 0)
+            {
+                return new Slot { ItemCount = 0 };
+            }
+
+            int itemId = reader.ReadVarInt();
+            int addedCount = reader.ReadVarInt();
+            int removedCount = reader.ReadVarInt();
+            SlotComponent[] components = ReadComponents(ref reader, protocolVersion, addedCount);
+            SlotComponentType[] removed = ReadRemovedComponents(ref reader, protocolVersion, removedCount);
+            return new Slot
+            {
+                ItemId = itemId,
+                ItemCount = itemCount,
+                Components = components,
+                RemovedComponents = removed
+            };
+        }
+
+        int count = reader.ReadVarInt();
+        if (count == 0)
+        {
+            return new Slot { ItemCount = 0 };
+        }
+
+        int itemIdNew = reader.ReadVarInt();
+        int addedComponentCount = reader.ReadVarInt();
+        int removedComponentCount = reader.ReadVarInt();
+        SlotComponent[] addedComponents = ReadComponents(ref reader, protocolVersion, addedComponentCount);
+        SlotComponentType[] removedComponents = ReadRemovedComponents(ref reader, protocolVersion, removedComponentCount);
+        return new Slot
+        {
+            ItemId = itemIdNew,
+            ItemCount = count,
+            Components = addedComponents,
+            RemovedComponents = removedComponents
+        };
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<Slot>(protocolVersion);
+        if (protocolVersion <= 763)
+        {
+            if (ItemId is null || ItemCount is null)
+            {
+                writer.WriteBoolean(false);
+                return;
+            }
+
+            writer.WriteBoolean(true);
+            writer.WriteVarInt(ItemId.Value);
+            writer.WriteSignedByte((sbyte)ItemCount.Value);
+            writer.WriteOptionalNbtTag(Nbt, protocolVersion);
+            return;
+        }
+
+        if (protocolVersion <= 765)
+        {
+            if (ItemId is null || ItemCount is null)
+            {
+                writer.WriteBoolean(false);
+                return;
+            }
+
+            writer.WriteBoolean(true);
+            writer.WriteVarInt(ItemId.Value);
+            writer.WriteSignedByte((sbyte)ItemCount.Value);
+            writer.WriteAnonOptionalNbtTag(Nbt, protocolVersion);
+            return;
+        }
+
+        int count = ItemCount.GetValueOrDefault(0);
+        if (protocolVersion == 766)
+        {
+            writer.WriteSignedByte((sbyte)count);
+            if (count == 0)
+            {
+                return;
+            }
+
+            writer.WriteVarInt(ItemId ?? 0);
+            WriteComponentCounts(ref writer, Components, RemovedComponents);
+            WriteComponentsWithoutCount(ref writer, protocolVersion, Components ?? Array.Empty<SlotComponent>());
+            WriteRemovedComponentsWithoutCount(ref writer, protocolVersion, RemovedComponents ?? Array.Empty<SlotComponentType>());
+            return;
+        }
+
+        writer.WriteVarInt(count);
+        if (count == 0)
+        {
+            return;
+        }
+
+        writer.WriteVarInt(ItemId ?? 0);
+        WriteComponentCounts(ref writer, Components, RemovedComponents);
+        WriteComponentsWithoutCount(ref writer, protocolVersion, Components ?? Array.Empty<SlotComponent>());
+        WriteRemovedComponentsWithoutCount(ref writer, protocolVersion, RemovedComponents ?? Array.Empty<SlotComponentType>());
+    }
+
+    private static SlotComponent[] ReadComponents(ref MinecraftPrimitiveReader reader, int protocolVersion, int count)
+    {
+        if (count == 0)
+        {
+            return Array.Empty<SlotComponent>();
+        }
+
+        var components = new SlotComponent[count];
+        for (int i = 0; i < count; i++)
+        {
+            components[i] = SlotComponent.Read(ref reader, protocolVersion);
+        }
+
+        return components;
+    }
+
+    private static SlotComponentType[] ReadRemovedComponents(ref MinecraftPrimitiveReader reader, int protocolVersion, int count)
+    {
+        if (count == 0)
+        {
+            return Array.Empty<SlotComponentType>();
+        }
+
+        var components = new SlotComponentType[count];
+        for (int i = 0; i < count; i++)
+        {
+            components[i] = SlotComponentTypeExtensions.Read(ref reader, protocolVersion);
+        }
+
+        return components;
+    }
+
+    private static void WriteComponentCounts(ref MinecraftPrimitiveWriter writer, IReadOnlyList<SlotComponent>? components,
+        IReadOnlyList<SlotComponentType>? removed)
+    {
+        writer.WriteVarInt(components?.Count ?? 0);
+        writer.WriteVarInt(removed?.Count ?? 0);
+    }
+
+    private static void WriteComponentsWithoutCount(ref MinecraftPrimitiveWriter writer, int protocolVersion,
+        IReadOnlyList<SlotComponent> components)
+    {
+        for (int i = 0; i < components.Count; i++)
+        {
+            components[i].Write(ref writer, protocolVersion);
+        }
+    }
+
+    private static void WriteRemovedComponentsWithoutCount(ref MinecraftPrimitiveWriter writer, int protocolVersion,
+        IReadOnlyList<SlotComponentType> removed)
+    {
+        for (int i = 0; i < removed.Count; i++)
+        {
+            removed[i].Write(ref writer, protocolVersion);
+        }
+    }
 }

--- a/src/McProtoNet.Protocol/Types/SlotComponent.cs
+++ b/src/McProtoNet.Protocol/Types/SlotComponent.cs
@@ -1,0 +1,2038 @@
+using Dunet;
+using McProtoNet.NBT;
+using McProtoNet.Protocol.Attributes;
+using McProtoNet.Serialization;
+
+namespace McProtoNet.Protocol;
+
+[Union]
+[ProtocolSupport(766, MinecraftVersion.LatestProtocol)]
+public partial record SlotComponent
+{
+    public sealed record AttributeModifiers(AttributeModifierEntry[] Attributes, bool? ShowTooltip, AttributeModifierDisplay? Display) : SlotComponent;
+    public sealed record AxolotlVariant(int Value) : SlotComponent;
+    public sealed record BannerPatterns(BannerPatternLayer[] Layers) : SlotComponent;
+    public sealed record BaseColor(int Value) : SlotComponent;
+    public sealed record Bees(BeeData[] Bees) : SlotComponent;
+    public sealed record BlockEntityData(NbtTag Data) : SlotComponent;
+    public sealed record BlockState(BlockStateProperty[] Properties) : SlotComponent;
+    public sealed record BlocksAttacks(BlocksAttacksData Data) : SlotComponent;
+    public sealed record BreakSound(ItemSoundHolder Sound) : SlotComponent;
+    public sealed record BucketEntityData(NbtTag Data) : SlotComponent;
+    public sealed record BundleContents(Slot[] Contents) : SlotComponent;
+    public sealed record CanBreak(ItemBlockPredicate[] Predicates, bool? ShowTooltip) : SlotComponent;
+    public sealed record CanPlaceOn(ItemBlockPredicate[] Predicates, bool? ShowTooltip) : SlotComponent;
+    public sealed record CatCollar(int Value) : SlotComponent;
+    public sealed record CatVariant(int Value) : SlotComponent;
+    public sealed record ChargedProjectiles(Slot[] Projectiles) : SlotComponent;
+    public sealed record ChickenVariant(RegistryEntryHolder<string> Variant) : SlotComponent;
+    public sealed record Consumable(ConsumableData Data) : SlotComponent;
+    public sealed record Container(Slot[] Contents) : SlotComponent;
+    public sealed record ContainerLoot(NbtTag Data) : SlotComponent;
+    public sealed record CowVariant(int Value) : SlotComponent;
+    public sealed record CreativeSlotLock() : SlotComponent;
+    public sealed record CustomData(NbtTag Data) : SlotComponent;
+    public sealed record CustomModelData(int? LegacyValue, float[]? Floats, bool[]? Flags, string[]? Strings, int[]? Colors) : SlotComponent;
+    public sealed record CustomName(NbtTag Data) : SlotComponent;
+    public sealed record Damage(int Value) : SlotComponent;
+    public sealed record DamageResistant(string Value) : SlotComponent;
+    public sealed record DeathProtection(ItemConsumeEffect[] Effects) : SlotComponent;
+    public sealed record DebugStickState(NbtTag Data) : SlotComponent;
+    public sealed record DyedColor(int Color, bool? ShowTooltip) : SlotComponent;
+    public sealed record Enchantable(int Value) : SlotComponent;
+    public sealed record EnchantmentGlintOverride(bool Value) : SlotComponent;
+    public sealed record Enchantments(EnchantmentEntry[] Enchantments, bool? ShowTooltip) : SlotComponent;
+    public sealed record EntityData(NbtTag Data) : SlotComponent;
+    public sealed record Equippable(EquippableData Data) : SlotComponent;
+    public sealed record FireResistant() : SlotComponent;
+    public sealed record FireworkExplosion(ItemFireworkExplosion Explosion) : SlotComponent;
+    public sealed record Fireworks(FireworksData Data) : SlotComponent;
+    public sealed record Food(FoodData Data) : SlotComponent;
+    public sealed record FoxVariant(int Value) : SlotComponent;
+    public sealed record FrogVariant(int Value) : SlotComponent;
+    public sealed record Glider() : SlotComponent;
+    public sealed record HideAdditionalTooltip() : SlotComponent;
+    public sealed record HideTooltip() : SlotComponent;
+    public sealed record HorseVariant(int Value) : SlotComponent;
+    public sealed record Instrument(InstrumentComponentData Data) : SlotComponent;
+    public sealed record IntangibleProjectile(NbtTag? Data) : SlotComponent;
+    public sealed record ItemModel(string Model) : SlotComponent;
+    public sealed record ItemName(NbtTag Data) : SlotComponent;
+    public sealed record JukeboxPlayable(JukeboxPlayableData Data) : SlotComponent;
+    public sealed record LlamaVariant(int Value) : SlotComponent;
+    public sealed record Lock(NbtTag Data) : SlotComponent;
+    public sealed record LodestoneTracker(LodestoneTrackerData Data) : SlotComponent;
+    public sealed record Lore(NbtTag?[] Lines) : SlotComponent;
+    public sealed record MapColor(int Color) : SlotComponent;
+    public sealed record MapDecorations(NbtTag Data) : SlotComponent;
+    public sealed record MapId(int Value) : SlotComponent;
+    public sealed record MapPostProcessing(int Value) : SlotComponent;
+    public sealed record MaxDamage(int Value) : SlotComponent;
+    public sealed record MaxStackSize(int Value) : SlotComponent;
+    public sealed record MooshroomVariant(int Value) : SlotComponent;
+    public sealed record NoteBlockSound(string Value) : SlotComponent;
+    public sealed record OminousBottleAmplifier(int Value) : SlotComponent;
+    public sealed record PaintingVariant(RegistryEntryHolder<EntityMetadataPaintingVariant> Variant) : SlotComponent;
+    public sealed record ParrotVariant(int Value) : SlotComponent;
+    public sealed record PigVariant(int Value) : SlotComponent;
+    public sealed record PotDecorations(int[] Decorations) : SlotComponent;
+    public sealed record PotionContents(PotionContentsData Data) : SlotComponent;
+    public sealed record PotionDurationScale(float Value) : SlotComponent;
+    public sealed record Profile(ProfileData Data) : SlotComponent;
+    public sealed record ProvidesBannerPatterns(string Value) : SlotComponent;
+    public sealed record ProvidesTrimMaterial(ProvidesTrimMaterialData Data) : SlotComponent;
+    public sealed record RabbitVariant(int Value) : SlotComponent;
+    public sealed record Rarity(string Value) : SlotComponent;
+    public sealed record Recipes(NbtTag Data) : SlotComponent;
+    public sealed record RepairCost(int Value) : SlotComponent;
+    public sealed record Repairable(IDSet Items) : SlotComponent;
+    public sealed record SalmonSize(int Value) : SlotComponent;
+    public sealed record SheepColor(int Value) : SlotComponent;
+    public sealed record ShulkerColor(int Value) : SlotComponent;
+    public sealed record StoredEnchantments(EnchantmentEntry[] Enchantments, bool? ShowInTooltip) : SlotComponent;
+    public sealed record SuspiciousStewEffects(SuspiciousStewEffect[] Effects) : SlotComponent;
+    public sealed record Tool(ToolData Data) : SlotComponent;
+    public sealed record TooltipDisplay(TooltipDisplayData Data) : SlotComponent;
+    public sealed record TooltipStyle(string Value) : SlotComponent;
+    public sealed record Trim(TrimData Data) : SlotComponent;
+    public sealed record TropicalFishBaseColor(int Value) : SlotComponent;
+    public sealed record TropicalFishPattern(int Value) : SlotComponent;
+    public sealed record TropicalFishPatternColor(int Value) : SlotComponent;
+    public sealed record Unbreakable(bool? Value) : SlotComponent;
+    public sealed record UseCooldown(UseCooldownData Data) : SlotComponent;
+    public sealed record UseRemainder(Slot Value) : SlotComponent;
+    public sealed record VillagerVariant(int Value) : SlotComponent;
+    public sealed record Weapon(WeaponData Data) : SlotComponent;
+    public sealed record WolfCollar(int Value) : SlotComponent;
+    public sealed record WolfSoundVariant(int Value) : SlotComponent;
+    public sealed record WolfVariant(int Value) : SlotComponent;
+    public sealed record WritableBookContent(ItemBookPage[] Pages) : SlotComponent;
+    public sealed record WrittenBookContent(WrittenBookContentData Data) : SlotComponent;
+
+    public sealed record AttributeModifierEntry(int TypeId, Guid? Uuid, string Name, double Value, string Operation, string Slot);
+    public sealed record AttributeModifierDisplay(string Type, NbtTag? Component);
+    public sealed record BeeData(NbtTag NbtData, int TicksInHive, int MinTicksInHive);
+    public sealed record BlockStateProperty(string Name, string Value);
+    public sealed record BlocksAttacksData(float BlockDelaySeconds, float DisableCooldownScale, DamageReduction[] DamageReductions,
+        ItemDamageData ItemDamage, string? BypassedBy, ItemSoundHolder? BlockSound, ItemSoundHolder? DisableSound);
+    public sealed record ConsumableData(float ConsumeSeconds, string Animation, ItemSoundHolder Sound, bool MakesParticles,
+        ItemConsumeEffect[] Effects);
+    public sealed record DamageReduction(float HorizontalBlockingAngle, IDSet? Type, float Base, float Factor);
+    public sealed record EquippableData(string Slot, ItemSoundHolder Sound, string? Model, string? CameraOverlay, IDSet? AllowedEntities,
+        bool Dispensable, bool Swappable, bool Damageable, bool? EquipOnInteract, bool? Shearable, ItemSoundHolder? ShearingSound);
+    public sealed record EnchantmentEntry(int Id, int Level);
+    public sealed record FireworksData(int FlightDuration, ItemFireworkExplosion[] Explosions);
+    public sealed record FoodData(int Nutrition, float SaturationModifier, bool CanAlwaysEat, float? SecondsToEat,
+        Slot? UsingConvertsTo, FoodEffect[]? Effects);
+    public sealed record FoodEffect(int Effect, float Probability);
+    public sealed record InstrumentComponentData(RegistryEntryHolder<InstrumentData>? Holder, string? InlineId);
+    public sealed record ItemDamageData(float Threshold, float Base, float Factor);
+    public sealed record JukeboxPlayableData(RegistryEntryHolder<JukeboxSongData>? Holder, string? Song, bool? ShowInTooltip);
+    public sealed record LodestonePosition(string Dimension, Position Position);
+    public sealed record LodestoneTrackerData(LodestonePosition? GlobalPosition, bool Tracked);
+    public sealed record PotionContentsData(int? PotionId, int? CustomColor, ItemPotionEffect[] CustomEffects, string? CustomName);
+    public sealed record ProfileData(string? Name, Guid? Uuid, ProfileProperty[] Properties);
+    public sealed record ProfileProperty(string Name, string Value, string? Signature);
+    public sealed record ProvidesTrimMaterialData(RegistryEntryHolder<ArmorTrimMaterial>? Holder, string? MaterialId);
+    public sealed record SuspiciousStewEffect(int Effect, int Duration);
+    public sealed record ToolData(ToolRule[] Rules, float DefaultMiningSpeed, int DamagePerBlock, bool? CanDestroyBlocksInCreative);
+    public sealed record ToolRule(IDSet Blocks, float? Speed, bool? CorrectDropForBlocks);
+    public sealed record TooltipDisplayData(bool HideTooltip, int[] HiddenComponents);
+    public sealed record TrimData(RegistryEntryHolder<ArmorTrimMaterial> Material, RegistryEntryHolder<ArmorTrimPattern> Pattern,
+        bool? ShowInTooltip);
+    public sealed record UseCooldownData(float Seconds, string? CooldownGroup);
+    public sealed record WeaponData(int ItemDamagePerAttack, float DisableBlockingForSeconds);
+    public sealed record WrittenBookContentData(string RawTitle, string? FilteredTitle, string Author, int Generation,
+        ItemWrittenBookPage[] Pages, bool Resolved);
+
+    public static SlotComponent Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<SlotComponent>(protocolVersion);
+        var type = SlotComponentTypeExtensions.Read(ref reader, protocolVersion);
+        return type switch
+        {
+            SlotComponentType.CustomData => new CustomData(reader.ReadAnonymousNbtTag(protocolVersion) ?? throw new InvalidOperationException("custom_data missing")),
+            SlotComponentType.MaxStackSize => new MaxStackSize(reader.ReadVarInt()),
+            SlotComponentType.MaxDamage => new MaxDamage(reader.ReadVarInt()),
+            SlotComponentType.Damage => new Damage(reader.ReadVarInt()),
+            SlotComponentType.Unbreakable => protocolVersion >= 770
+                ? new Unbreakable(null)
+                : new Unbreakable(reader.ReadBoolean()),
+            SlotComponentType.CustomName => new CustomName(reader.ReadAnonymousNbtTag(protocolVersion) ?? throw new InvalidOperationException("custom_name missing")),
+            SlotComponentType.ItemName => new ItemName(reader.ReadAnonymousNbtTag(protocolVersion) ?? throw new InvalidOperationException("item_name missing")),
+            SlotComponentType.ItemModel => protocolVersion >= 768
+                ? new ItemModel(reader.ReadString())
+                : throw new InvalidOperationException("item_model is not supported before protocol 768"),
+            SlotComponentType.Lore => new Lore(ReadLore(ref reader, protocolVersion)),
+            SlotComponentType.Rarity => new Rarity(ReadRarity(reader.ReadVarInt())),
+            SlotComponentType.Enchantments => new Enchantments(ReadEnchantments(ref reader),
+                protocolVersion <= 769 ? reader.ReadBoolean() : null),
+            SlotComponentType.CanPlaceOn => new CanPlaceOn(ReadItemBlockPredicates(ref reader, protocolVersion),
+                protocolVersion <= 769 ? reader.ReadBoolean() : null),
+            SlotComponentType.CanBreak => new CanBreak(ReadItemBlockPredicates(ref reader, protocolVersion),
+                protocolVersion <= 769 ? reader.ReadBoolean() : null),
+            SlotComponentType.AttributeModifiers => ReadAttributeModifiers(ref reader, protocolVersion),
+            SlotComponentType.CustomModelData => ReadCustomModelData(ref reader, protocolVersion),
+            SlotComponentType.HideAdditionalTooltip => protocolVersion <= 769
+                ? new HideAdditionalTooltip()
+                : throw new InvalidOperationException("hide_additional_tooltip not supported in protocol 770+"),
+            SlotComponentType.HideTooltip => protocolVersion <= 769
+                ? new HideTooltip()
+                : throw new InvalidOperationException("hide_tooltip not supported in protocol 770+"),
+            SlotComponentType.TooltipDisplay => protocolVersion >= 770
+                ? new TooltipDisplay(ReadTooltipDisplay(ref reader))
+                : throw new InvalidOperationException("tooltip_display is not supported before protocol 770"),
+            SlotComponentType.RepairCost => new RepairCost(reader.ReadVarInt()),
+            SlotComponentType.CreativeSlotLock => new CreativeSlotLock(),
+            SlotComponentType.EnchantmentGlintOverride => new EnchantmentGlintOverride(reader.ReadBoolean()),
+            SlotComponentType.IntangibleProjectile => protocolVersion >= 770
+                ? new IntangibleProjectile(null)
+                : new IntangibleProjectile(reader.ReadAnonymousNbtTag(protocolVersion)),
+            SlotComponentType.Food => new Food(ReadFood(ref reader, protocolVersion)),
+            SlotComponentType.FireResistant => protocolVersion <= 769
+                ? new FireResistant()
+                : throw new InvalidOperationException("fire_resistant not supported in protocol 770+"),
+            SlotComponentType.Tool => new Tool(ReadTool(ref reader, protocolVersion)),
+            SlotComponentType.StoredEnchantments => new StoredEnchantments(ReadEnchantments(ref reader),
+                protocolVersion <= 769 ? reader.ReadBoolean() : null),
+            SlotComponentType.DyedColor => protocolVersion >= 770
+                ? new DyedColor(reader.ReadSignedInt(), null)
+                : new DyedColor(reader.ReadSignedInt(), reader.ReadBoolean()),
+            SlotComponentType.MapColor => new MapColor(reader.ReadSignedInt()),
+            SlotComponentType.MapId => new MapId(reader.ReadVarInt()),
+            SlotComponentType.MapDecorations => new MapDecorations(reader.ReadAnonymousNbtTag(protocolVersion) ?? throw new InvalidOperationException("map_decorations missing")),
+            SlotComponentType.MapPostProcessing => new MapPostProcessing(reader.ReadVarInt()),
+            SlotComponentType.ChargedProjectiles => new ChargedProjectiles(ReadSlotArray(ref reader, protocolVersion)),
+            SlotComponentType.BundleContents => new BundleContents(ReadSlotArray(ref reader, protocolVersion)),
+            SlotComponentType.PotionContents => new PotionContents(ReadPotionContents(ref reader, protocolVersion)),
+            SlotComponentType.SuspiciousStewEffects => new SuspiciousStewEffects(ReadSuspiciousStewEffects(ref reader)),
+            SlotComponentType.WritableBookContent => new WritableBookContent(ReadItemBookPages(ref reader, protocolVersion)),
+            SlotComponentType.WrittenBookContent => new WrittenBookContent(ReadWrittenBookContent(ref reader, protocolVersion)),
+            SlotComponentType.Trim => new Trim(ReadTrim(ref reader, protocolVersion)),
+            SlotComponentType.DebugStickState => new DebugStickState(reader.ReadAnonymousNbtTag(protocolVersion) ?? throw new InvalidOperationException("debug_stick_state missing")),
+            SlotComponentType.EntityData => new EntityData(reader.ReadAnonymousNbtTag(protocolVersion) ?? throw new InvalidOperationException("entity_data missing")),
+            SlotComponentType.BucketEntityData => new BucketEntityData(reader.ReadAnonymousNbtTag(protocolVersion) ?? throw new InvalidOperationException("bucket_entity_data missing")),
+            SlotComponentType.BlockEntityData => new BlockEntityData(reader.ReadAnonymousNbtTag(protocolVersion) ?? throw new InvalidOperationException("block_entity_data missing")),
+            SlotComponentType.Instrument => new Instrument(ReadInstrument(ref reader, protocolVersion)),
+            SlotComponentType.OminousBottleAmplifier => new OminousBottleAmplifier(reader.ReadVarInt()),
+            SlotComponentType.Recipes => new Recipes(reader.ReadAnonymousNbtTag(protocolVersion) ?? throw new InvalidOperationException("recipes missing")),
+            SlotComponentType.LodestoneTracker => new LodestoneTracker(ReadLodestoneTracker(ref reader, protocolVersion)),
+            SlotComponentType.FireworkExplosion => new FireworkExplosion(ItemFireworkExplosion.Read(ref reader, protocolVersion)),
+            SlotComponentType.Fireworks => new Fireworks(ReadFireworks(ref reader, protocolVersion)),
+            SlotComponentType.Profile => new Profile(ReadProfile(ref reader, protocolVersion)),
+            SlotComponentType.NoteBlockSound => new NoteBlockSound(reader.ReadString()),
+            SlotComponentType.BannerPatterns => new BannerPatterns(ReadBannerPatterns(ref reader, protocolVersion)),
+            SlotComponentType.BaseColor => new BaseColor(reader.ReadVarInt()),
+            SlotComponentType.PotDecorations => new PotDecorations(ReadVarIntArray(ref reader)),
+            SlotComponentType.Container => new Container(ReadSlotArray(ref reader, protocolVersion)),
+            SlotComponentType.BlockState => new BlockState(ReadBlockState(ref reader, protocolVersion)),
+            SlotComponentType.Bees => new Bees(ReadBees(ref reader, protocolVersion)),
+            SlotComponentType.Lock => new Lock(reader.ReadAnonymousNbtTag(protocolVersion) ?? throw new InvalidOperationException("lock missing")),
+            SlotComponentType.ContainerLoot => new ContainerLoot(reader.ReadAnonymousNbtTag(protocolVersion) ?? throw new InvalidOperationException("container_loot missing")),
+            SlotComponentType.JukeboxPlayable => protocolVersion >= 767
+                ? new JukeboxPlayable(ReadJukeboxPlayable(ref reader, protocolVersion))
+                : throw new InvalidOperationException("jukebox_playable is not supported before protocol 767"),
+            SlotComponentType.Consumable => protocolVersion >= 768
+                ? new Consumable(ReadConsumable(ref reader, protocolVersion))
+                : throw new InvalidOperationException("consumable is not supported before protocol 768"),
+            SlotComponentType.UseRemainder => protocolVersion >= 768
+                ? new UseRemainder(Slot.Read(ref reader, protocolVersion))
+                : throw new InvalidOperationException("use_remainder is not supported before protocol 768"),
+            SlotComponentType.UseCooldown => protocolVersion >= 768
+                ? new UseCooldown(ReadUseCooldown(ref reader))
+                : throw new InvalidOperationException("use_cooldown is not supported before protocol 768"),
+            SlotComponentType.DamageResistant => protocolVersion >= 768
+                ? new DamageResistant(reader.ReadString())
+                : throw new InvalidOperationException("damage_resistant is not supported before protocol 768"),
+            SlotComponentType.Enchantable => protocolVersion >= 768
+                ? new Enchantable(reader.ReadVarInt())
+                : throw new InvalidOperationException("enchantable is not supported before protocol 768"),
+            SlotComponentType.Equippable => protocolVersion >= 768
+                ? new Equippable(ReadEquippable(ref reader, protocolVersion))
+                : throw new InvalidOperationException("equippable is not supported before protocol 768"),
+            SlotComponentType.Repairable => protocolVersion >= 768
+                ? new Repairable(IDSet.Read(ref reader, protocolVersion))
+                : throw new InvalidOperationException("repairable is not supported before protocol 768"),
+            SlotComponentType.Glider => protocolVersion >= 768
+                ? new Glider()
+                : throw new InvalidOperationException("glider is not supported before protocol 768"),
+            SlotComponentType.TooltipStyle => protocolVersion >= 768
+                ? new TooltipStyle(reader.ReadString())
+                : throw new InvalidOperationException("tooltip_style is not supported before protocol 768"),
+            SlotComponentType.DeathProtection => protocolVersion >= 768
+                ? new DeathProtection(ReadItemConsumeEffects(ref reader, protocolVersion))
+                : throw new InvalidOperationException("death_protection is not supported before protocol 768"),
+            SlotComponentType.Weapon => protocolVersion >= 770
+                ? new Weapon(ReadWeapon(ref reader))
+                : throw new InvalidOperationException("weapon is not supported before protocol 770"),
+            SlotComponentType.BlocksAttacks => protocolVersion >= 770
+                ? new BlocksAttacks(ReadBlocksAttacks(ref reader, protocolVersion))
+                : throw new InvalidOperationException("blocks_attacks is not supported before protocol 770"),
+            SlotComponentType.PotionDurationScale => protocolVersion >= 770
+                ? new PotionDurationScale(reader.ReadFloat())
+                : throw new InvalidOperationException("potion_duration_scale is not supported before protocol 770"),
+            SlotComponentType.ProvidesTrimMaterial => protocolVersion >= 770
+                ? new ProvidesTrimMaterial(ReadProvidesTrimMaterial(ref reader, protocolVersion))
+                : throw new InvalidOperationException("provides_trim_material is not supported before protocol 770"),
+            SlotComponentType.ProvidesBannerPatterns => protocolVersion >= 770
+                ? new ProvidesBannerPatterns(reader.ReadString())
+                : throw new InvalidOperationException("provides_banner_patterns is not supported before protocol 770"),
+            SlotComponentType.BreakSound => protocolVersion >= 770
+                ? new BreakSound(ItemSoundHolder.Read(ref reader, protocolVersion))
+                : throw new InvalidOperationException("break_sound is not supported before protocol 770"),
+            SlotComponentType.VillagerVariant => protocolVersion >= 770
+                ? new VillagerVariant(reader.ReadVarInt())
+                : throw new InvalidOperationException("villager/variant is not supported before protocol 770"),
+            SlotComponentType.WolfVariant => protocolVersion >= 770
+                ? new WolfVariant(reader.ReadVarInt())
+                : throw new InvalidOperationException("wolf/variant is not supported before protocol 770"),
+            SlotComponentType.WolfSoundVariant => protocolVersion >= 770
+                ? new WolfSoundVariant(reader.ReadVarInt())
+                : throw new InvalidOperationException("wolf/sound_variant is not supported before protocol 770"),
+            SlotComponentType.WolfCollar => protocolVersion >= 770
+                ? new WolfCollar(reader.ReadVarInt())
+                : throw new InvalidOperationException("wolf/collar is not supported before protocol 770"),
+            SlotComponentType.FoxVariant => protocolVersion >= 770
+                ? new FoxVariant(reader.ReadVarInt())
+                : throw new InvalidOperationException("fox/variant is not supported before protocol 770"),
+            SlotComponentType.SalmonSize => protocolVersion >= 770
+                ? new SalmonSize(reader.ReadVarInt())
+                : throw new InvalidOperationException("salmon/size is not supported before protocol 770"),
+            SlotComponentType.ParrotVariant => protocolVersion >= 770
+                ? new ParrotVariant(reader.ReadVarInt())
+                : throw new InvalidOperationException("parrot/variant is not supported before protocol 770"),
+            SlotComponentType.TropicalFishPattern => protocolVersion >= 770
+                ? new TropicalFishPattern(reader.ReadVarInt())
+                : throw new InvalidOperationException("tropical_fish/pattern is not supported before protocol 770"),
+            SlotComponentType.TropicalFishBaseColor => protocolVersion >= 770
+                ? new TropicalFishBaseColor(reader.ReadVarInt())
+                : throw new InvalidOperationException("tropical_fish/base_color is not supported before protocol 770"),
+            SlotComponentType.TropicalFishPatternColor => protocolVersion >= 770
+                ? new TropicalFishPatternColor(reader.ReadVarInt())
+                : throw new InvalidOperationException("tropical_fish/pattern_color is not supported before protocol 770"),
+            SlotComponentType.MooshroomVariant => protocolVersion >= 770
+                ? new MooshroomVariant(reader.ReadVarInt())
+                : throw new InvalidOperationException("mooshroom/variant is not supported before protocol 770"),
+            SlotComponentType.RabbitVariant => protocolVersion >= 770
+                ? new RabbitVariant(reader.ReadVarInt())
+                : throw new InvalidOperationException("rabbit/variant is not supported before protocol 770"),
+            SlotComponentType.PigVariant => protocolVersion >= 770
+                ? new PigVariant(reader.ReadVarInt())
+                : throw new InvalidOperationException("pig/variant is not supported before protocol 770"),
+            SlotComponentType.CowVariant => protocolVersion >= 770
+                ? new CowVariant(reader.ReadVarInt())
+                : throw new InvalidOperationException("cow/variant is not supported before protocol 770"),
+            SlotComponentType.ChickenVariant => protocolVersion >= 770
+                ? new ChickenVariant(RegistryEntryHolder<string>.Read(ref reader, protocolVersion))
+                : throw new InvalidOperationException("chicken/variant is not supported before protocol 770"),
+            SlotComponentType.FrogVariant => protocolVersion >= 770
+                ? new FrogVariant(reader.ReadVarInt())
+                : throw new InvalidOperationException("frog/variant is not supported before protocol 770"),
+            SlotComponentType.HorseVariant => protocolVersion >= 770
+                ? new HorseVariant(reader.ReadVarInt())
+                : throw new InvalidOperationException("horse/variant is not supported before protocol 770"),
+            SlotComponentType.PaintingVariant => protocolVersion >= 770
+                ? new PaintingVariant(RegistryEntryHolder<EntityMetadataPaintingVariant>.Read(ref reader, protocolVersion))
+                : throw new InvalidOperationException("painting/variant is not supported before protocol 770"),
+            SlotComponentType.LlamaVariant => protocolVersion >= 770
+                ? new LlamaVariant(reader.ReadVarInt())
+                : throw new InvalidOperationException("llama/variant is not supported before protocol 770"),
+            SlotComponentType.AxolotlVariant => protocolVersion >= 770
+                ? new AxolotlVariant(reader.ReadVarInt())
+                : throw new InvalidOperationException("axolotl/variant is not supported before protocol 770"),
+            SlotComponentType.CatVariant => protocolVersion >= 770
+                ? new CatVariant(reader.ReadVarInt())
+                : throw new InvalidOperationException("cat/variant is not supported before protocol 770"),
+            SlotComponentType.CatCollar => protocolVersion >= 770
+                ? new CatCollar(reader.ReadVarInt())
+                : throw new InvalidOperationException("cat/collar is not supported before protocol 770"),
+            SlotComponentType.SheepColor => protocolVersion >= 770
+                ? new SheepColor(reader.ReadVarInt())
+                : throw new InvalidOperationException("sheep/color is not supported before protocol 770"),
+            SlotComponentType.ShulkerColor => protocolVersion >= 770
+                ? new ShulkerColor(reader.ReadVarInt())
+                : throw new InvalidOperationException("shulker/color is not supported before protocol 770"),
+            _ => throw new InvalidOperationException($"Unhandled SlotComponentType {type}")
+        };
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<SlotComponent>(protocolVersion);
+        var type = GetComponentType();
+        type.Write(ref writer, protocolVersion);
+        switch (this)
+        {
+            case CustomData customData:
+                writer.WriteAnonymousNbtTag(customData.Data, protocolVersion);
+                break;
+            case MaxStackSize maxStackSize:
+                writer.WriteVarInt(maxStackSize.Value);
+                break;
+            case MaxDamage maxDamage:
+                writer.WriteVarInt(maxDamage.Value);
+                break;
+            case Damage damage:
+                writer.WriteVarInt(damage.Value);
+                break;
+            case Unbreakable unbreakable:
+                if (protocolVersion <= 769)
+                {
+                    writer.WriteBoolean(unbreakable.Value ?? false);
+                }
+                break;
+            case CustomName customName:
+                writer.WriteAnonymousNbtTag(customName.Data, protocolVersion);
+                break;
+            case ItemName itemName:
+                writer.WriteAnonymousNbtTag(itemName.Data, protocolVersion);
+                break;
+            case ItemModel itemModel:
+                if (protocolVersion < 768)
+                {
+                    throw new InvalidOperationException("item_model is not supported before protocol 768");
+                }
+                writer.WriteString(itemModel.Model);
+                break;
+            case Lore lore:
+                WriteLore(ref writer, lore.Lines, protocolVersion);
+                break;
+            case Rarity rarity:
+                writer.WriteVarInt(WriteRarity(rarity.Value));
+                break;
+            case Enchantments enchantments:
+                WriteEnchantments(ref writer, enchantments.Enchantments);
+                if (protocolVersion <= 769)
+                {
+                    writer.WriteBoolean(enchantments.ShowTooltip ?? false);
+                }
+                break;
+            case CanPlaceOn canPlaceOn:
+                WriteItemBlockPredicates(ref writer, canPlaceOn.Predicates, protocolVersion);
+                if (protocolVersion <= 769)
+                {
+                    writer.WriteBoolean(canPlaceOn.ShowTooltip ?? false);
+                }
+                break;
+            case CanBreak canBreak:
+                WriteItemBlockPredicates(ref writer, canBreak.Predicates, protocolVersion);
+                if (protocolVersion <= 769)
+                {
+                    writer.WriteBoolean(canBreak.ShowTooltip ?? false);
+                }
+                break;
+            case AttributeModifiers attributeModifiers:
+                WriteAttributeModifiers(ref writer, attributeModifiers, protocolVersion);
+                break;
+            case CustomModelData customModelData:
+                WriteCustomModelData(ref writer, customModelData, protocolVersion);
+                break;
+            case HideAdditionalTooltip:
+                if (protocolVersion >= 770)
+                {
+                    throw new InvalidOperationException("hide_additional_tooltip not supported in protocol 770+");
+                }
+                break;
+            case HideTooltip:
+                if (protocolVersion >= 770)
+                {
+                    throw new InvalidOperationException("hide_tooltip not supported in protocol 770+");
+                }
+                break;
+            case TooltipDisplay tooltipDisplay:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("tooltip_display is not supported before protocol 770");
+                }
+                WriteTooltipDisplay(ref writer, tooltipDisplay.Data);
+                break;
+            case RepairCost repairCost:
+                writer.WriteVarInt(repairCost.Value);
+                break;
+            case CreativeSlotLock:
+                break;
+            case EnchantmentGlintOverride glintOverride:
+                writer.WriteBoolean(glintOverride.Value);
+                break;
+            case IntangibleProjectile intangibleProjectile:
+                if (protocolVersion <= 769)
+                {
+                    writer.WriteAnonymousNbtTag(intangibleProjectile.Data ?? throw new InvalidOperationException("intangible_projectile missing"),
+                        protocolVersion);
+                }
+                break;
+            case Food food:
+                WriteFood(ref writer, food.Data, protocolVersion);
+                break;
+            case FireResistant:
+                if (protocolVersion >= 770)
+                {
+                    throw new InvalidOperationException("fire_resistant not supported in protocol 770+");
+                }
+                break;
+            case Tool tool:
+                WriteTool(ref writer, tool.Data, protocolVersion);
+                break;
+            case StoredEnchantments storedEnchantments:
+                WriteEnchantments(ref writer, storedEnchantments.Enchantments);
+                if (protocolVersion <= 769)
+                {
+                    writer.WriteBoolean(storedEnchantments.ShowInTooltip ?? false);
+                }
+                break;
+            case DyedColor dyedColor:
+                writer.WriteSignedInt(dyedColor.Color);
+                if (protocolVersion <= 769)
+                {
+                    writer.WriteBoolean(dyedColor.ShowTooltip ?? false);
+                }
+                break;
+            case MapColor mapColor:
+                writer.WriteSignedInt(mapColor.Color);
+                break;
+            case MapId mapId:
+                writer.WriteVarInt(mapId.Value);
+                break;
+            case MapDecorations mapDecorations:
+                writer.WriteAnonymousNbtTag(mapDecorations.Data, protocolVersion);
+                break;
+            case MapPostProcessing mapPostProcessing:
+                writer.WriteVarInt(mapPostProcessing.Value);
+                break;
+            case ChargedProjectiles chargedProjectiles:
+                WriteSlotArray(ref writer, chargedProjectiles.Projectiles, protocolVersion);
+                break;
+            case BundleContents bundleContents:
+                WriteSlotArray(ref writer, bundleContents.Contents, protocolVersion);
+                break;
+            case PotionContents potionContents:
+                WritePotionContents(ref writer, potionContents.Data, protocolVersion);
+                break;
+            case SuspiciousStewEffects suspiciousStewEffects:
+                WriteSuspiciousStewEffects(ref writer, suspiciousStewEffects.Effects);
+                break;
+            case WritableBookContent writableBookContent:
+                WriteItemBookPages(ref writer, writableBookContent.Pages, protocolVersion);
+                break;
+            case WrittenBookContent writtenBookContent:
+                WriteWrittenBookContent(ref writer, writtenBookContent.Data, protocolVersion);
+                break;
+            case Trim trim:
+                WriteTrim(ref writer, trim.Data, protocolVersion);
+                break;
+            case DebugStickState debugStickState:
+                writer.WriteAnonymousNbtTag(debugStickState.Data, protocolVersion);
+                break;
+            case EntityData entityData:
+                writer.WriteAnonymousNbtTag(entityData.Data, protocolVersion);
+                break;
+            case BucketEntityData bucketEntityData:
+                writer.WriteAnonymousNbtTag(bucketEntityData.Data, protocolVersion);
+                break;
+            case BlockEntityData blockEntityData:
+                writer.WriteAnonymousNbtTag(blockEntityData.Data, protocolVersion);
+                break;
+            case Instrument instrument:
+                WriteInstrument(ref writer, instrument.Data, protocolVersion);
+                break;
+            case OminousBottleAmplifier ominousBottleAmplifier:
+                writer.WriteVarInt(ominousBottleAmplifier.Value);
+                break;
+            case Recipes recipes:
+                writer.WriteAnonymousNbtTag(recipes.Data, protocolVersion);
+                break;
+            case LodestoneTracker lodestoneTracker:
+                WriteLodestoneTracker(ref writer, lodestoneTracker.Data, protocolVersion);
+                break;
+            case FireworkExplosion fireworkExplosion:
+                fireworkExplosion.Explosion.Write(ref writer, protocolVersion);
+                break;
+            case Fireworks fireworks:
+                WriteFireworks(ref writer, fireworks.Data, protocolVersion);
+                break;
+            case Profile profile:
+                WriteProfile(ref writer, profile.Data, protocolVersion);
+                break;
+            case NoteBlockSound noteBlockSound:
+                writer.WriteString(noteBlockSound.Value);
+                break;
+            case BannerPatterns bannerPatterns:
+                WriteBannerPatterns(ref writer, bannerPatterns.Layers, protocolVersion);
+                break;
+            case BaseColor baseColor:
+                writer.WriteVarInt(baseColor.Value);
+                break;
+            case PotDecorations potDecorations:
+                WriteVarIntArray(ref writer, potDecorations.Decorations);
+                break;
+            case Container container:
+                WriteSlotArray(ref writer, container.Contents, protocolVersion);
+                break;
+            case BlockState blockState:
+                WriteBlockState(ref writer, blockState.Properties, protocolVersion);
+                break;
+            case Bees bees:
+                WriteBees(ref writer, bees.Bees, protocolVersion);
+                break;
+            case Lock lockData:
+                writer.WriteAnonymousNbtTag(lockData.Data, protocolVersion);
+                break;
+            case ContainerLoot containerLoot:
+                writer.WriteAnonymousNbtTag(containerLoot.Data, protocolVersion);
+                break;
+            case JukeboxPlayable jukeboxPlayable:
+                if (protocolVersion < 767)
+                {
+                    throw new InvalidOperationException("jukebox_playable is not supported before protocol 767");
+                }
+                WriteJukeboxPlayable(ref writer, jukeboxPlayable.Data, protocolVersion);
+                break;
+            case Consumable consumable:
+                if (protocolVersion < 768)
+                {
+                    throw new InvalidOperationException("consumable is not supported before protocol 768");
+                }
+                WriteConsumable(ref writer, consumable.Data, protocolVersion);
+                break;
+            case UseRemainder useRemainder:
+                if (protocolVersion < 768)
+                {
+                    throw new InvalidOperationException("use_remainder is not supported before protocol 768");
+                }
+                useRemainder.Value.Write(ref writer, protocolVersion);
+                break;
+            case UseCooldown useCooldown:
+                if (protocolVersion < 768)
+                {
+                    throw new InvalidOperationException("use_cooldown is not supported before protocol 768");
+                }
+                WriteUseCooldown(ref writer, useCooldown.Data);
+                break;
+            case DamageResistant damageResistant:
+                if (protocolVersion < 768)
+                {
+                    throw new InvalidOperationException("damage_resistant is not supported before protocol 768");
+                }
+                writer.WriteString(damageResistant.Value);
+                break;
+            case Enchantable enchantable:
+                if (protocolVersion < 768)
+                {
+                    throw new InvalidOperationException("enchantable is not supported before protocol 768");
+                }
+                writer.WriteVarInt(enchantable.Value);
+                break;
+            case Equippable equippable:
+                if (protocolVersion < 768)
+                {
+                    throw new InvalidOperationException("equippable is not supported before protocol 768");
+                }
+                WriteEquippable(ref writer, equippable.Data, protocolVersion);
+                break;
+            case Repairable repairable:
+                if (protocolVersion < 768)
+                {
+                    throw new InvalidOperationException("repairable is not supported before protocol 768");
+                }
+                repairable.Items.Write(ref writer, protocolVersion);
+                break;
+            case Glider:
+                if (protocolVersion < 768)
+                {
+                    throw new InvalidOperationException("glider is not supported before protocol 768");
+                }
+                break;
+            case TooltipStyle tooltipStyle:
+                if (protocolVersion < 768)
+                {
+                    throw new InvalidOperationException("tooltip_style is not supported before protocol 768");
+                }
+                writer.WriteString(tooltipStyle.Value);
+                break;
+            case DeathProtection deathProtection:
+                if (protocolVersion < 768)
+                {
+                    throw new InvalidOperationException("death_protection is not supported before protocol 768");
+                }
+                WriteItemConsumeEffects(ref writer, deathProtection.Effects, protocolVersion);
+                break;
+            case Weapon weapon:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("weapon is not supported before protocol 770");
+                }
+                WriteWeapon(ref writer, weapon.Data);
+                break;
+            case BlocksAttacks blocksAttacks:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("blocks_attacks is not supported before protocol 770");
+                }
+                WriteBlocksAttacks(ref writer, blocksAttacks.Data, protocolVersion);
+                break;
+            case PotionDurationScale potionDurationScale:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("potion_duration_scale is not supported before protocol 770");
+                }
+                writer.WriteFloat(potionDurationScale.Value);
+                break;
+            case ProvidesTrimMaterial providesTrimMaterial:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("provides_trim_material is not supported before protocol 770");
+                }
+                WriteProvidesTrimMaterial(ref writer, providesTrimMaterial.Data, protocolVersion);
+                break;
+            case ProvidesBannerPatterns providesBannerPatterns:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("provides_banner_patterns is not supported before protocol 770");
+                }
+                writer.WriteString(providesBannerPatterns.Value);
+                break;
+            case BreakSound breakSound:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("break_sound is not supported before protocol 770");
+                }
+                breakSound.Sound.Write(ref writer, protocolVersion);
+                break;
+            case VillagerVariant villagerVariant:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("villager/variant is not supported before protocol 770");
+                }
+                writer.WriteVarInt(villagerVariant.Value);
+                break;
+            case WolfVariant wolfVariant:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("wolf/variant is not supported before protocol 770");
+                }
+                writer.WriteVarInt(wolfVariant.Value);
+                break;
+            case WolfSoundVariant wolfSoundVariant:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("wolf/sound_variant is not supported before protocol 770");
+                }
+                writer.WriteVarInt(wolfSoundVariant.Value);
+                break;
+            case WolfCollar wolfCollar:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("wolf/collar is not supported before protocol 770");
+                }
+                writer.WriteVarInt(wolfCollar.Value);
+                break;
+            case FoxVariant foxVariant:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("fox/variant is not supported before protocol 770");
+                }
+                writer.WriteVarInt(foxVariant.Value);
+                break;
+            case SalmonSize salmonSize:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("salmon/size is not supported before protocol 770");
+                }
+                writer.WriteVarInt(salmonSize.Value);
+                break;
+            case ParrotVariant parrotVariant:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("parrot/variant is not supported before protocol 770");
+                }
+                writer.WriteVarInt(parrotVariant.Value);
+                break;
+            case TropicalFishPattern tropicalFishPattern:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("tropical_fish/pattern is not supported before protocol 770");
+                }
+                writer.WriteVarInt(tropicalFishPattern.Value);
+                break;
+            case TropicalFishBaseColor tropicalFishBaseColor:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("tropical_fish/base_color is not supported before protocol 770");
+                }
+                writer.WriteVarInt(tropicalFishBaseColor.Value);
+                break;
+            case TropicalFishPatternColor tropicalFishPatternColor:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("tropical_fish/pattern_color is not supported before protocol 770");
+                }
+                writer.WriteVarInt(tropicalFishPatternColor.Value);
+                break;
+            case MooshroomVariant mooshroomVariant:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("mooshroom/variant is not supported before protocol 770");
+                }
+                writer.WriteVarInt(mooshroomVariant.Value);
+                break;
+            case RabbitVariant rabbitVariant:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("rabbit/variant is not supported before protocol 770");
+                }
+                writer.WriteVarInt(rabbitVariant.Value);
+                break;
+            case PigVariant pigVariant:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("pig/variant is not supported before protocol 770");
+                }
+                writer.WriteVarInt(pigVariant.Value);
+                break;
+            case CowVariant cowVariant:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("cow/variant is not supported before protocol 770");
+                }
+                writer.WriteVarInt(cowVariant.Value);
+                break;
+            case ChickenVariant chickenVariant:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("chicken/variant is not supported before protocol 770");
+                }
+                chickenVariant.Variant.Write(ref writer, protocolVersion);
+                break;
+            case FrogVariant frogVariant:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("frog/variant is not supported before protocol 770");
+                }
+                writer.WriteVarInt(frogVariant.Value);
+                break;
+            case HorseVariant horseVariant:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("horse/variant is not supported before protocol 770");
+                }
+                writer.WriteVarInt(horseVariant.Value);
+                break;
+            case PaintingVariant paintingVariant:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("painting/variant is not supported before protocol 770");
+                }
+                paintingVariant.Variant.Write(ref writer, protocolVersion);
+                break;
+            case LlamaVariant llamaVariant:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("llama/variant is not supported before protocol 770");
+                }
+                writer.WriteVarInt(llamaVariant.Value);
+                break;
+            case AxolotlVariant axolotlVariant:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("axolotl/variant is not supported before protocol 770");
+                }
+                writer.WriteVarInt(axolotlVariant.Value);
+                break;
+            case CatVariant catVariant:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("cat/variant is not supported before protocol 770");
+                }
+                writer.WriteVarInt(catVariant.Value);
+                break;
+            case CatCollar catCollar:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("cat/collar is not supported before protocol 770");
+                }
+                writer.WriteVarInt(catCollar.Value);
+                break;
+            case SheepColor sheepColor:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("sheep/color is not supported before protocol 770");
+                }
+                writer.WriteVarInt(sheepColor.Value);
+                break;
+            case ShulkerColor shulkerColor:
+                if (protocolVersion < 770)
+                {
+                    throw new InvalidOperationException("shulker/color is not supported before protocol 770");
+                }
+                writer.WriteVarInt(shulkerColor.Value);
+                break;
+        }
+    }
+
+    private static SlotComponentType GetComponentType(SlotComponent component)
+        => component switch
+        {
+            AttributeModifiers => SlotComponentType.AttributeModifiers,
+            AxolotlVariant => SlotComponentType.AxolotlVariant,
+            BannerPatterns => SlotComponentType.BannerPatterns,
+            BaseColor => SlotComponentType.BaseColor,
+            Bees => SlotComponentType.Bees,
+            BlockEntityData => SlotComponentType.BlockEntityData,
+            BlockState => SlotComponentType.BlockState,
+            BlocksAttacks => SlotComponentType.BlocksAttacks,
+            BreakSound => SlotComponentType.BreakSound,
+            BucketEntityData => SlotComponentType.BucketEntityData,
+            BundleContents => SlotComponentType.BundleContents,
+            CanBreak => SlotComponentType.CanBreak,
+            CanPlaceOn => SlotComponentType.CanPlaceOn,
+            CatCollar => SlotComponentType.CatCollar,
+            CatVariant => SlotComponentType.CatVariant,
+            ChargedProjectiles => SlotComponentType.ChargedProjectiles,
+            ChickenVariant => SlotComponentType.ChickenVariant,
+            Consumable => SlotComponentType.Consumable,
+            Container => SlotComponentType.Container,
+            ContainerLoot => SlotComponentType.ContainerLoot,
+            CowVariant => SlotComponentType.CowVariant,
+            CreativeSlotLock => SlotComponentType.CreativeSlotLock,
+            CustomData => SlotComponentType.CustomData,
+            CustomModelData => SlotComponentType.CustomModelData,
+            CustomName => SlotComponentType.CustomName,
+            Damage => SlotComponentType.Damage,
+            DamageResistant => SlotComponentType.DamageResistant,
+            DeathProtection => SlotComponentType.DeathProtection,
+            DebugStickState => SlotComponentType.DebugStickState,
+            DyedColor => SlotComponentType.DyedColor,
+            Enchantable => SlotComponentType.Enchantable,
+            EnchantmentGlintOverride => SlotComponentType.EnchantmentGlintOverride,
+            Enchantments => SlotComponentType.Enchantments,
+            EntityData => SlotComponentType.EntityData,
+            Equippable => SlotComponentType.Equippable,
+            FireResistant => SlotComponentType.FireResistant,
+            FireworkExplosion => SlotComponentType.FireworkExplosion,
+            Fireworks => SlotComponentType.Fireworks,
+            Food => SlotComponentType.Food,
+            FoxVariant => SlotComponentType.FoxVariant,
+            FrogVariant => SlotComponentType.FrogVariant,
+            Glider => SlotComponentType.Glider,
+            HideAdditionalTooltip => SlotComponentType.HideAdditionalTooltip,
+            HideTooltip => SlotComponentType.HideTooltip,
+            HorseVariant => SlotComponentType.HorseVariant,
+            Instrument => SlotComponentType.Instrument,
+            IntangibleProjectile => SlotComponentType.IntangibleProjectile,
+            ItemModel => SlotComponentType.ItemModel,
+            ItemName => SlotComponentType.ItemName,
+            JukeboxPlayable => SlotComponentType.JukeboxPlayable,
+            LlamaVariant => SlotComponentType.LlamaVariant,
+            Lock => SlotComponentType.Lock,
+            LodestoneTracker => SlotComponentType.LodestoneTracker,
+            Lore => SlotComponentType.Lore,
+            MapColor => SlotComponentType.MapColor,
+            MapDecorations => SlotComponentType.MapDecorations,
+            MapId => SlotComponentType.MapId,
+            MapPostProcessing => SlotComponentType.MapPostProcessing,
+            MaxDamage => SlotComponentType.MaxDamage,
+            MaxStackSize => SlotComponentType.MaxStackSize,
+            MooshroomVariant => SlotComponentType.MooshroomVariant,
+            NoteBlockSound => SlotComponentType.NoteBlockSound,
+            OminousBottleAmplifier => SlotComponentType.OminousBottleAmplifier,
+            PaintingVariant => SlotComponentType.PaintingVariant,
+            ParrotVariant => SlotComponentType.ParrotVariant,
+            PigVariant => SlotComponentType.PigVariant,
+            PotDecorations => SlotComponentType.PotDecorations,
+            PotionContents => SlotComponentType.PotionContents,
+            PotionDurationScale => SlotComponentType.PotionDurationScale,
+            Profile => SlotComponentType.Profile,
+            ProvidesBannerPatterns => SlotComponentType.ProvidesBannerPatterns,
+            ProvidesTrimMaterial => SlotComponentType.ProvidesTrimMaterial,
+            RabbitVariant => SlotComponentType.RabbitVariant,
+            Rarity => SlotComponentType.Rarity,
+            Recipes => SlotComponentType.Recipes,
+            RepairCost => SlotComponentType.RepairCost,
+            Repairable => SlotComponentType.Repairable,
+            SalmonSize => SlotComponentType.SalmonSize,
+            SheepColor => SlotComponentType.SheepColor,
+            ShulkerColor => SlotComponentType.ShulkerColor,
+            StoredEnchantments => SlotComponentType.StoredEnchantments,
+            SuspiciousStewEffects => SlotComponentType.SuspiciousStewEffects,
+            Tool => SlotComponentType.Tool,
+            TooltipDisplay => SlotComponentType.TooltipDisplay,
+            TooltipStyle => SlotComponentType.TooltipStyle,
+            Trim => SlotComponentType.Trim,
+            TropicalFishBaseColor => SlotComponentType.TropicalFishBaseColor,
+            TropicalFishPattern => SlotComponentType.TropicalFishPattern,
+            TropicalFishPatternColor => SlotComponentType.TropicalFishPatternColor,
+            Unbreakable => SlotComponentType.Unbreakable,
+            UseCooldown => SlotComponentType.UseCooldown,
+            UseRemainder => SlotComponentType.UseRemainder,
+            VillagerVariant => SlotComponentType.VillagerVariant,
+            Weapon => SlotComponentType.Weapon,
+            WolfCollar => SlotComponentType.WolfCollar,
+            WolfSoundVariant => SlotComponentType.WolfSoundVariant,
+            WolfVariant => SlotComponentType.WolfVariant,
+            WritableBookContent => SlotComponentType.WritableBookContent,
+            WrittenBookContent => SlotComponentType.WrittenBookContent,
+            _ => throw new InvalidOperationException($"Unknown SlotComponent {component.GetType()}")
+        };
+
+    private SlotComponentType GetComponentType() => GetComponentType(this);
+
+    private static AttributeModifiers ReadAttributeModifiers(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        var attributes = ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => ReadAttributeModifierEntry(ref r, protocolVersion));
+        bool? showTooltip = null;
+        AttributeModifierDisplay? display = null;
+        if (protocolVersion <= 770)
+        {
+            showTooltip = reader.ReadBoolean();
+        }
+        else
+        {
+            display = ReadAttributeModifierDisplay(ref reader, protocolVersion);
+        }
+
+        return new AttributeModifiers(attributes, showTooltip, display);
+    }
+
+    private static AttributeModifierEntry ReadAttributeModifierEntry(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        int typeId = reader.ReadVarInt();
+        Guid? uuid = null;
+        string name;
+        if (protocolVersion == 766)
+        {
+            uuid = reader.ReadUUID();
+            name = reader.ReadString();
+        }
+        else
+        {
+            name = reader.ReadString();
+        }
+        double value = reader.ReadDouble();
+        string operation = ReadOperation(reader.ReadVarInt());
+        string slot = ReadAttributeSlot(reader.ReadVarInt(), protocolVersion);
+        return new AttributeModifierEntry(typeId, uuid, name, value, operation, slot);
+    }
+
+    private static AttributeModifierDisplay ReadAttributeModifierDisplay(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        string type = ReadDisplayType(reader.ReadVarInt());
+        NbtTag? component = null;
+        if (type == "override")
+        {
+            component = reader.ReadAnonymousNbtTag(protocolVersion);
+        }
+        return new AttributeModifierDisplay(type, component);
+    }
+
+    private static void WriteAttributeModifiers(ref MinecraftPrimitiveWriter writer, AttributeModifiers data, int protocolVersion)
+    {
+        WriteArray(ref writer, data.Attributes, (ref MinecraftPrimitiveWriter w, AttributeModifierEntry entry) =>
+        {
+            WriteAttributeModifierEntry(ref w, entry, protocolVersion);
+        });
+
+        if (protocolVersion <= 770)
+        {
+            writer.WriteBoolean(data.ShowTooltip ?? false);
+        }
+        else
+        {
+            WriteAttributeModifierDisplay(ref writer, data.Display, protocolVersion);
+        }
+    }
+
+    private static void WriteAttributeModifierEntry(ref MinecraftPrimitiveWriter writer, AttributeModifierEntry entry, int protocolVersion)
+    {
+        writer.WriteVarInt(entry.TypeId);
+        if (protocolVersion == 766)
+        {
+            writer.WriteUUID(entry.Uuid ?? Guid.Empty);
+            writer.WriteString(entry.Name);
+        }
+        else
+        {
+            writer.WriteString(entry.Name);
+        }
+        writer.WriteDouble(entry.Value);
+        writer.WriteVarInt(WriteOperation(entry.Operation));
+        writer.WriteVarInt(WriteAttributeSlot(entry.Slot, protocolVersion));
+    }
+
+    private static void WriteAttributeModifierDisplay(ref MinecraftPrimitiveWriter writer, AttributeModifierDisplay? display,
+        int protocolVersion)
+    {
+        if (display is null)
+        {
+            writer.WriteVarInt(WriteDisplayType("default"));
+            return;
+        }
+
+        writer.WriteVarInt(WriteDisplayType(display.Type));
+        if (display.Type == "override")
+        {
+            writer.WriteAnonymousNbtTag(display.Component ?? throw new InvalidOperationException("display component missing"), protocolVersion);
+        }
+    }
+
+    private static CustomModelData ReadCustomModelData(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        if (protocolVersion <= 767)
+        {
+            return new CustomModelData(reader.ReadVarInt(), null, null, null, null);
+        }
+
+        float[] floats = ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => r.ReadFloat());
+        bool[] flags = ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => r.ReadBoolean());
+        string[] strings = ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => r.ReadString());
+        int[] colors = ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => r.ReadSignedInt());
+        return new CustomModelData(null, floats, flags, strings, colors);
+    }
+
+    private static void WriteCustomModelData(ref MinecraftPrimitiveWriter writer, CustomModelData data, int protocolVersion)
+    {
+        if (protocolVersion <= 767)
+        {
+            writer.WriteVarInt(data.LegacyValue ?? 0);
+            return;
+        }
+
+        WriteArray(ref writer, data.Floats ?? Array.Empty<float>(), (ref MinecraftPrimitiveWriter w, float value) => w.WriteFloat(value));
+        WriteArray(ref writer, data.Flags ?? Array.Empty<bool>(), (ref MinecraftPrimitiveWriter w, bool value) => w.WriteBoolean(value));
+        WriteArray(ref writer, data.Strings ?? Array.Empty<string>(), (ref MinecraftPrimitiveWriter w, string value) => w.WriteString(value));
+        WriteArray(ref writer, data.Colors ?? Array.Empty<int>(), (ref MinecraftPrimitiveWriter w, int value) => w.WriteSignedInt(value));
+    }
+
+    private static NbtTag?[] ReadLore(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        return ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => protocolVersion <= 769
+            ? r.ReadAnonOptionalNbtTag(protocolVersion)
+            : r.ReadAnonymousNbtTag(protocolVersion));
+    }
+
+    private static void WriteLore(ref MinecraftPrimitiveWriter writer, IReadOnlyList<NbtTag?> lines, int protocolVersion)
+    {
+        WriteArray(ref writer, lines, (ref MinecraftPrimitiveWriter w, NbtTag? line) =>
+        {
+            if (protocolVersion <= 769)
+            {
+                w.WriteAnonOptionalNbtTag(line, protocolVersion);
+            }
+            else
+            {
+                w.WriteAnonymousNbtTag(line ?? throw new InvalidOperationException("lore entry missing"), protocolVersion);
+            }
+        });
+    }
+
+    private static EnchantmentEntry[] ReadEnchantments(ref MinecraftPrimitiveReader reader)
+    {
+        return ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => new EnchantmentEntry(r.ReadVarInt(), r.ReadVarInt()));
+    }
+
+    private static void WriteEnchantments(ref MinecraftPrimitiveWriter writer, IReadOnlyList<EnchantmentEntry> entries)
+    {
+        WriteArray(ref writer, entries, (ref MinecraftPrimitiveWriter w, EnchantmentEntry entry) =>
+        {
+            w.WriteVarInt(entry.Id);
+            w.WriteVarInt(entry.Level);
+        });
+    }
+
+    private static ItemBlockPredicate[] ReadItemBlockPredicates(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        return ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => ItemBlockPredicate.Read(ref r, protocolVersion));
+    }
+
+    private static void WriteItemBlockPredicates(ref MinecraftPrimitiveWriter writer, IReadOnlyList<ItemBlockPredicate> predicates,
+        int protocolVersion)
+    {
+        WriteArray(ref writer, predicates, (ref MinecraftPrimitiveWriter w, ItemBlockPredicate predicate) =>
+        {
+            predicate.Write(ref w, protocolVersion);
+        });
+    }
+
+    private static FoodData ReadFood(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        int nutrition = reader.ReadVarInt();
+        float saturation = reader.ReadFloat();
+        bool canAlwaysEat = reader.ReadBoolean();
+        float? secondsToEat = null;
+        Slot? usingConvertsTo = null;
+        FoodEffect[]? effects = null;
+        if (protocolVersion <= 767)
+        {
+            secondsToEat = reader.ReadFloat();
+            usingConvertsTo = Slot.Read(ref reader, protocolVersion);
+            effects = ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => new FoodEffect(r.ReadVarInt(), r.ReadFloat()));
+        }
+        return new FoodData(nutrition, saturation, canAlwaysEat, secondsToEat, usingConvertsTo, effects);
+    }
+
+    private static void WriteFood(ref MinecraftPrimitiveWriter writer, FoodData data, int protocolVersion)
+    {
+        writer.WriteVarInt(data.Nutrition);
+        writer.WriteFloat(data.SaturationModifier);
+        writer.WriteBoolean(data.CanAlwaysEat);
+        if (protocolVersion <= 767)
+        {
+            writer.WriteFloat(data.SecondsToEat ?? 0f);
+            (data.UsingConvertsTo ?? new Slot()).Write(ref writer, protocolVersion);
+            WriteArray(ref writer, data.Effects ?? Array.Empty<FoodEffect>(), (ref MinecraftPrimitiveWriter w, FoodEffect effect) =>
+            {
+                w.WriteVarInt(effect.Effect);
+                w.WriteFloat(effect.Probability);
+            });
+        }
+    }
+
+    private static ToolData ReadTool(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ToolRule[] rules = ReadArray(ref reader, (ref MinecraftPrimitiveReader r) =>
+        {
+            var blocks = IDSet.Read(ref r, protocolVersion);
+            float? speed = ReadOptionalFloat(ref r);
+            bool? correct = ReadOptionalBool(ref r);
+            return new ToolRule(blocks, speed, correct);
+        });
+        float defaultSpeed = reader.ReadFloat();
+        int damagePerBlock = reader.ReadVarInt();
+        bool? canDestroyBlocks = null;
+        if (protocolVersion >= 770)
+        {
+            canDestroyBlocks = reader.ReadBoolean();
+        }
+        return new ToolData(rules, defaultSpeed, damagePerBlock, canDestroyBlocks);
+    }
+
+    private static void WriteTool(ref MinecraftPrimitiveWriter writer, ToolData data, int protocolVersion)
+    {
+        WriteArray(ref writer, data.Rules, (ref MinecraftPrimitiveWriter w, ToolRule rule) =>
+        {
+            rule.Blocks.Write(ref w, protocolVersion);
+            WriteOptionalFloat(ref w, rule.Speed);
+            WriteOptionalBool(ref w, rule.CorrectDropForBlocks);
+        });
+        writer.WriteFloat(data.DefaultMiningSpeed);
+        writer.WriteVarInt(data.DamagePerBlock);
+        if (protocolVersion >= 770)
+        {
+            writer.WriteBoolean(data.CanDestroyBlocksInCreative ?? false);
+        }
+    }
+
+    private static PotionContentsData ReadPotionContents(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        int? potionId = ReadOptionalVarInt(ref reader);
+        int? customColor = ReadOptionalSignedInt(ref reader);
+        ItemPotionEffect[] effects = ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => ItemPotionEffect.Read(ref r, protocolVersion));
+        string? customName = ReadOptionalString(ref reader);
+        return new PotionContentsData(potionId, customColor, effects, customName);
+    }
+
+    private static void WritePotionContents(ref MinecraftPrimitiveWriter writer, PotionContentsData data, int protocolVersion)
+    {
+        WriteOptionalVarInt(ref writer, data.PotionId);
+        WriteOptionalSignedInt(ref writer, data.CustomColor);
+        WriteArray(ref writer, data.CustomEffects, (ref MinecraftPrimitiveWriter w, ItemPotionEffect effect) => effect.Write(ref w, protocolVersion));
+        WriteOptionalString(ref writer, data.CustomName);
+    }
+
+    private static SuspiciousStewEffect[] ReadSuspiciousStewEffects(ref MinecraftPrimitiveReader reader)
+    {
+        return ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => new SuspiciousStewEffect(r.ReadVarInt(), r.ReadVarInt()));
+    }
+
+    private static void WriteSuspiciousStewEffects(ref MinecraftPrimitiveWriter writer, IReadOnlyList<SuspiciousStewEffect> effects)
+    {
+        WriteArray(ref writer, effects, (ref MinecraftPrimitiveWriter w, SuspiciousStewEffect effect) =>
+        {
+            w.WriteVarInt(effect.Effect);
+            w.WriteVarInt(effect.Duration);
+        });
+    }
+
+    private static ItemBookPage[] ReadItemBookPages(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        return ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => ItemBookPage.Read(ref r, protocolVersion));
+    }
+
+    private static void WriteItemBookPages(ref MinecraftPrimitiveWriter writer, IReadOnlyList<ItemBookPage> pages, int protocolVersion)
+    {
+        WriteArray(ref writer, pages, (ref MinecraftPrimitiveWriter w, ItemBookPage page) => page.Write(ref w, protocolVersion));
+    }
+
+    private static WrittenBookContentData ReadWrittenBookContent(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        string rawTitle = reader.ReadString();
+        string? filteredTitle = ReadOptionalString(ref reader);
+        string author = reader.ReadString();
+        int generation = reader.ReadVarInt();
+        ItemWrittenBookPage[] pages = ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => ItemWrittenBookPage.Read(ref r, protocolVersion));
+        bool resolved = reader.ReadBoolean();
+        return new WrittenBookContentData(rawTitle, filteredTitle, author, generation, pages, resolved);
+    }
+
+    private static void WriteWrittenBookContent(ref MinecraftPrimitiveWriter writer, WrittenBookContentData data, int protocolVersion)
+    {
+        writer.WriteString(data.RawTitle);
+        WriteOptionalString(ref writer, data.FilteredTitle);
+        writer.WriteString(data.Author);
+        writer.WriteVarInt(data.Generation);
+        WriteArray(ref writer, data.Pages, (ref MinecraftPrimitiveWriter w, ItemWrittenBookPage page) => page.Write(ref w, protocolVersion));
+        writer.WriteBoolean(data.Resolved);
+    }
+
+    private static TrimData ReadTrim(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        var material = RegistryEntryHolder<ArmorTrimMaterial>.Read(ref reader, protocolVersion);
+        var pattern = RegistryEntryHolder<ArmorTrimPattern>.Read(ref reader, protocolVersion);
+        bool? showInTooltip = null;
+        if (protocolVersion <= 769)
+        {
+            showInTooltip = reader.ReadBoolean();
+        }
+        return new TrimData(material, pattern, showInTooltip);
+    }
+
+    private static void WriteTrim(ref MinecraftPrimitiveWriter writer, TrimData data, int protocolVersion)
+    {
+        data.Material.Write(ref writer, protocolVersion);
+        data.Pattern.Write(ref writer, protocolVersion);
+        if (protocolVersion <= 769)
+        {
+            writer.WriteBoolean(data.ShowInTooltip ?? false);
+        }
+    }
+
+    private static InstrumentComponentData ReadInstrument(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        if (protocolVersion <= 769)
+        {
+            var holder = RegistryEntryHolder<InstrumentData>.Read(ref reader, protocolVersion);
+            return new InstrumentComponentData(holder, null);
+        }
+
+        bool hasHolder = reader.ReadBoolean();
+        if (hasHolder)
+        {
+            return new InstrumentComponentData(RegistryEntryHolder<InstrumentData>.Read(ref reader, protocolVersion), null);
+        }
+
+        return new InstrumentComponentData(null, reader.ReadString());
+    }
+
+    private static void WriteInstrument(ref MinecraftPrimitiveWriter writer, InstrumentComponentData data, int protocolVersion)
+    {
+        if (protocolVersion <= 769)
+        {
+            (data.Holder ?? throw new InvalidOperationException("instrument holder missing")).Write(ref writer, protocolVersion);
+            return;
+        }
+
+        bool hasHolder = data.Holder is not null;
+        writer.WriteBoolean(hasHolder);
+        if (hasHolder)
+        {
+            data.Holder!.Write(ref writer, protocolVersion);
+        }
+        else
+        {
+            writer.WriteString(data.InlineId ?? string.Empty);
+        }
+    }
+
+    private static JukeboxPlayableData ReadJukeboxPlayable(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        bool hasHolder = reader.ReadBoolean();
+        RegistryEntryHolder<JukeboxSongData>? holder = null;
+        string? song = null;
+        if (hasHolder)
+        {
+            holder = RegistryEntryHolder<JukeboxSongData>.Read(ref reader, protocolVersion);
+        }
+        else
+        {
+            song = reader.ReadString();
+        }
+
+        bool? showInTooltip = null;
+        if (protocolVersion <= 769)
+        {
+            showInTooltip = reader.ReadBoolean();
+        }
+        return new JukeboxPlayableData(holder, song, showInTooltip);
+    }
+
+    private static void WriteJukeboxPlayable(ref MinecraftPrimitiveWriter writer, JukeboxPlayableData data, int protocolVersion)
+    {
+        bool hasHolder = data.Holder is not null;
+        writer.WriteBoolean(hasHolder);
+        if (hasHolder)
+        {
+            data.Holder!.Write(ref writer, protocolVersion);
+        }
+        else
+        {
+            writer.WriteString(data.Song ?? string.Empty);
+        }
+
+        if (protocolVersion <= 769)
+        {
+            writer.WriteBoolean(data.ShowInTooltip ?? false);
+        }
+    }
+
+    private static LodestoneTrackerData ReadLodestoneTracker(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        LodestonePosition? position = null;
+        if (reader.ReadBoolean())
+        {
+            string dimension = reader.ReadString();
+            Position pos = reader.ReadPosition(protocolVersion);
+            position = new LodestonePosition(dimension, pos);
+        }
+        bool tracked = reader.ReadBoolean();
+        return new LodestoneTrackerData(position, tracked);
+    }
+
+    private static void WriteLodestoneTracker(ref MinecraftPrimitiveWriter writer, LodestoneTrackerData data, int protocolVersion)
+    {
+        if (data.GlobalPosition is null)
+        {
+            writer.WriteBoolean(false);
+        }
+        else
+        {
+            writer.WriteBoolean(true);
+            writer.WriteString(data.GlobalPosition.Dimension);
+            writer.WritePosition(data.GlobalPosition.Position, protocolVersion);
+        }
+        writer.WriteBoolean(data.Tracked);
+    }
+
+    private static FireworksData ReadFireworks(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        int flightDuration = reader.ReadVarInt();
+        ItemFireworkExplosion[] explosions = ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => ItemFireworkExplosion.Read(ref r, protocolVersion));
+        return new FireworksData(flightDuration, explosions);
+    }
+
+    private static void WriteFireworks(ref MinecraftPrimitiveWriter writer, FireworksData data, int protocolVersion)
+    {
+        writer.WriteVarInt(data.FlightDuration);
+        WriteArray(ref writer, data.Explosions, (ref MinecraftPrimitiveWriter w, ItemFireworkExplosion explosion) => explosion.Write(ref w, protocolVersion));
+    }
+
+    private static ProfileData ReadProfile(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        string? name = ReadOptionalString(ref reader);
+        Guid? uuid = ReadOptionalUuid(ref reader);
+        ProfileProperty[] properties = ReadArray(ref reader, (ref MinecraftPrimitiveReader r) =>
+        {
+            string propName = r.ReadString();
+            string value = r.ReadString();
+            string? signature = ReadOptionalString(ref r);
+            return new ProfileProperty(propName, value, signature);
+        });
+        return new ProfileData(name, uuid, properties);
+    }
+
+    private static void WriteProfile(ref MinecraftPrimitiveWriter writer, ProfileData data, int protocolVersion)
+    {
+        WriteOptionalString(ref writer, data.Name);
+        WriteOptionalUuid(ref writer, data.Uuid);
+        WriteArray(ref writer, data.Properties, (ref MinecraftPrimitiveWriter w, ProfileProperty property) =>
+        {
+            w.WriteString(property.Name);
+            w.WriteString(property.Value);
+            WriteOptionalString(ref w, property.Signature);
+        });
+    }
+
+    private static BannerPatternLayer[] ReadBannerPatterns(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        return ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => BannerPatternLayer.Read(ref r, protocolVersion));
+    }
+
+    private static void WriteBannerPatterns(ref MinecraftPrimitiveWriter writer, IReadOnlyList<BannerPatternLayer> layers, int protocolVersion)
+    {
+        WriteArray(ref writer, layers, (ref MinecraftPrimitiveWriter w, BannerPatternLayer layer) => layer.Write(ref w, protocolVersion));
+    }
+
+    private static int[] ReadVarIntArray(ref MinecraftPrimitiveReader reader)
+    {
+        return ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => r.ReadVarInt());
+    }
+
+    private static void WriteVarIntArray(ref MinecraftPrimitiveWriter writer, IReadOnlyList<int> values)
+    {
+        WriteArray(ref writer, values, (ref MinecraftPrimitiveWriter w, int value) => w.WriteVarInt(value));
+    }
+
+    private static BlockStateProperty[] ReadBlockState(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        return ReadArray(ref reader, (ref MinecraftPrimitiveReader r) =>
+        {
+            string name = r.ReadString();
+            string value = r.ReadString();
+            return new BlockStateProperty(name, value);
+        });
+    }
+
+    private static void WriteBlockState(ref MinecraftPrimitiveWriter writer, IReadOnlyList<BlockStateProperty> properties,
+        int protocolVersion)
+    {
+        WriteArray(ref writer, properties, (ref MinecraftPrimitiveWriter w, BlockStateProperty property) =>
+        {
+            w.WriteString(property.Name);
+            w.WriteString(property.Value);
+        });
+    }
+
+    private static BeeData[] ReadBees(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        return ReadArray(ref reader, (ref MinecraftPrimitiveReader r) =>
+        {
+            var nbt = r.ReadAnonymousNbtTag(protocolVersion) ?? throw new InvalidOperationException("bee nbt missing");
+            int ticks = r.ReadVarInt();
+            int minTicks = r.ReadVarInt();
+            return new BeeData(nbt, ticks, minTicks);
+        });
+    }
+
+    private static void WriteBees(ref MinecraftPrimitiveWriter writer, IReadOnlyList<BeeData> bees, int protocolVersion)
+    {
+        WriteArray(ref writer, bees, (ref MinecraftPrimitiveWriter w, BeeData bee) =>
+        {
+            w.WriteAnonymousNbtTag(bee.NbtData, protocolVersion);
+            w.WriteVarInt(bee.TicksInHive);
+            w.WriteVarInt(bee.MinTicksInHive);
+        });
+    }
+
+    private static ConsumableData ReadConsumable(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        float seconds = reader.ReadFloat();
+        string animation = ReadConsumableAnimation(reader.ReadVarInt(), protocolVersion);
+        var sound = ItemSoundHolder.Read(ref reader, protocolVersion);
+        bool makesParticles = reader.ReadBoolean();
+        ItemConsumeEffect[] effects = ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => ItemConsumeEffect.Read(ref r, protocolVersion));
+        return new ConsumableData(seconds, animation, sound, makesParticles, effects);
+    }
+
+    private static void WriteConsumable(ref MinecraftPrimitiveWriter writer, ConsumableData data, int protocolVersion)
+    {
+        writer.WriteFloat(data.ConsumeSeconds);
+        writer.WriteVarInt(WriteConsumableAnimation(data.Animation, protocolVersion));
+        data.Sound.Write(ref writer, protocolVersion);
+        writer.WriteBoolean(data.MakesParticles);
+        WriteArray(ref writer, data.Effects, (ref MinecraftPrimitiveWriter w, ItemConsumeEffect effect) => effect.Write(ref w, protocolVersion));
+    }
+
+    private static UseCooldownData ReadUseCooldown(ref MinecraftPrimitiveReader reader)
+    {
+        float seconds = reader.ReadFloat();
+        string? cooldownGroup = ReadOptionalString(ref reader);
+        return new UseCooldownData(seconds, cooldownGroup);
+    }
+
+    private static void WriteUseCooldown(ref MinecraftPrimitiveWriter writer, UseCooldownData data)
+    {
+        writer.WriteFloat(data.Seconds);
+        WriteOptionalString(ref writer, data.CooldownGroup);
+    }
+
+    private static EquippableData ReadEquippable(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        string slot = ReadEquippableSlot(reader.ReadVarInt(), protocolVersion);
+        ItemSoundHolder sound = ItemSoundHolder.Read(ref reader, protocolVersion);
+        string? model = ReadOptionalString(ref reader);
+        string? cameraOverlay = ReadOptionalString(ref reader);
+        IDSet? allowedEntities = ReadOptionalIdSet(ref reader, protocolVersion);
+        bool dispensable = reader.ReadBoolean();
+        bool swappable = reader.ReadBoolean();
+        bool damageable = reader.ReadBoolean();
+        bool? equipOnInteract = null;
+        bool? shearable = null;
+        ItemSoundHolder? shearingSound = null;
+        if (protocolVersion >= 770)
+        {
+            equipOnInteract = reader.ReadBoolean();
+        }
+        if (protocolVersion >= 771)
+        {
+            shearable = reader.ReadBoolean();
+            shearingSound = ItemSoundHolder.Read(ref reader, protocolVersion);
+        }
+        return new EquippableData(slot, sound, model, cameraOverlay, allowedEntities, dispensable, swappable, damageable, equipOnInteract,
+            shearable, shearingSound);
+    }
+
+    private static void WriteEquippable(ref MinecraftPrimitiveWriter writer, EquippableData data, int protocolVersion)
+    {
+        writer.WriteVarInt(WriteEquippableSlot(data.Slot, protocolVersion));
+        data.Sound.Write(ref writer, protocolVersion);
+        WriteOptionalString(ref writer, data.Model);
+        WriteOptionalString(ref writer, data.CameraOverlay);
+        WriteOptionalIdSet(ref writer, data.AllowedEntities, protocolVersion);
+        writer.WriteBoolean(data.Dispensable);
+        writer.WriteBoolean(data.Swappable);
+        writer.WriteBoolean(data.Damageable);
+        if (protocolVersion >= 770)
+        {
+            writer.WriteBoolean(data.EquipOnInteract ?? false);
+        }
+        if (protocolVersion >= 771)
+        {
+            writer.WriteBoolean(data.Shearable ?? false);
+            (data.ShearingSound ?? new ItemSoundHolder()).Write(ref writer, protocolVersion);
+        }
+    }
+
+    private static ItemConsumeEffect[] ReadItemConsumeEffects(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        return ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => ItemConsumeEffect.Read(ref r, protocolVersion));
+    }
+
+    private static void WriteItemConsumeEffects(ref MinecraftPrimitiveWriter writer, IReadOnlyList<ItemConsumeEffect> effects,
+        int protocolVersion)
+    {
+        WriteArray(ref writer, effects, (ref MinecraftPrimitiveWriter w, ItemConsumeEffect effect) => effect.Write(ref w, protocolVersion));
+    }
+
+    private static TooltipDisplayData ReadTooltipDisplay(ref MinecraftPrimitiveReader reader)
+    {
+        bool hideTooltip = reader.ReadBoolean();
+        int[] hidden = ReadVarIntArray(ref reader);
+        return new TooltipDisplayData(hideTooltip, hidden);
+    }
+
+    private static void WriteTooltipDisplay(ref MinecraftPrimitiveWriter writer, TooltipDisplayData data)
+    {
+        writer.WriteBoolean(data.HideTooltip);
+        WriteVarIntArray(ref writer, data.HiddenComponents);
+    }
+
+    private static WeaponData ReadWeapon(ref MinecraftPrimitiveReader reader)
+    {
+        int itemDamage = reader.ReadVarInt();
+        float disableBlocking = reader.ReadFloat();
+        return new WeaponData(itemDamage, disableBlocking);
+    }
+
+    private static void WriteWeapon(ref MinecraftPrimitiveWriter writer, WeaponData data)
+    {
+        writer.WriteVarInt(data.ItemDamagePerAttack);
+        writer.WriteFloat(data.DisableBlockingForSeconds);
+    }
+
+    private static BlocksAttacksData ReadBlocksAttacks(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        float blockDelay = reader.ReadFloat();
+        float disableCooldown = reader.ReadFloat();
+        DamageReduction[] reductions = ReadArray(ref reader, (ref MinecraftPrimitiveReader r) =>
+        {
+            float angle = r.ReadFloat();
+            IDSet? type = ReadOptionalIdSet(ref r, protocolVersion);
+            float baseValue = r.ReadFloat();
+            float factor = r.ReadFloat();
+            return new DamageReduction(angle, type, baseValue, factor);
+        });
+        ItemDamageData itemDamage = new(reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat());
+        string? bypassedBy = ReadOptionalString(ref reader);
+        ItemSoundHolder? blockSound = ReadOptionalItemSoundHolder(ref reader, protocolVersion);
+        ItemSoundHolder? disableSound = ReadOptionalItemSoundHolder(ref reader, protocolVersion);
+        return new BlocksAttacksData(blockDelay, disableCooldown, reductions, itemDamage, bypassedBy, blockSound, disableSound);
+    }
+
+    private static void WriteBlocksAttacks(ref MinecraftPrimitiveWriter writer, BlocksAttacksData data, int protocolVersion)
+    {
+        writer.WriteFloat(data.BlockDelaySeconds);
+        writer.WriteFloat(data.DisableCooldownScale);
+        WriteArray(ref writer, data.DamageReductions, (ref MinecraftPrimitiveWriter w, DamageReduction reduction) =>
+        {
+            w.WriteFloat(reduction.HorizontalBlockingAngle);
+            WriteOptionalIdSet(ref w, reduction.Type, protocolVersion);
+            w.WriteFloat(reduction.Base);
+            w.WriteFloat(reduction.Factor);
+        });
+        writer.WriteFloat(data.ItemDamage.Threshold);
+        writer.WriteFloat(data.ItemDamage.Base);
+        writer.WriteFloat(data.ItemDamage.Factor);
+        WriteOptionalString(ref writer, data.BypassedBy);
+        WriteOptionalItemSoundHolder(ref writer, data.BlockSound, protocolVersion);
+        WriteOptionalItemSoundHolder(ref writer, data.DisableSound, protocolVersion);
+    }
+
+    private static ProvidesTrimMaterialData ReadProvidesTrimMaterial(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        bool hasHolder = reader.ReadBoolean();
+        if (hasHolder)
+        {
+            var holder = RegistryEntryHolder<ArmorTrimMaterial>.Read(ref reader, protocolVersion);
+            return new ProvidesTrimMaterialData(holder, null);
+        }
+
+        return new ProvidesTrimMaterialData(null, reader.ReadString());
+    }
+
+    private static void WriteProvidesTrimMaterial(ref MinecraftPrimitiveWriter writer, ProvidesTrimMaterialData data, int protocolVersion)
+    {
+        bool hasHolder = data.Holder is not null;
+        writer.WriteBoolean(hasHolder);
+        if (hasHolder)
+        {
+            data.Holder!.Write(ref writer, protocolVersion);
+        }
+        else
+        {
+            writer.WriteString(data.MaterialId ?? string.Empty);
+        }
+    }
+
+    private static Slot[] ReadSlotArray(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        return ReadArray(ref reader, (ref MinecraftPrimitiveReader r) => Slot.Read(ref r, protocolVersion));
+    }
+
+    private static void WriteSlotArray(ref MinecraftPrimitiveWriter writer, IReadOnlyList<Slot> slots, int protocolVersion)
+    {
+        WriteArray(ref writer, slots, (ref MinecraftPrimitiveWriter w, Slot slot) => slot.Write(ref w, protocolVersion));
+    }
+
+    private static string ReadRarity(int id)
+    {
+        return id switch
+        {
+            0 => "common",
+            1 => "uncommon",
+            2 => "rare",
+            3 => "epic",
+            _ => throw new InvalidOperationException($"Unknown rarity id {id}")
+        };
+    }
+
+    private static int WriteRarity(string value)
+    {
+        return value switch
+        {
+            "common" => 0,
+            "uncommon" => 1,
+            "rare" => 2,
+            "epic" => 3,
+            _ => throw new InvalidOperationException($"Unknown rarity value {value}")
+        };
+    }
+
+    private static string ReadOperation(int id)
+    {
+        return id switch
+        {
+            0 => "add",
+            1 => "multiply_base",
+            2 => "multiply_total",
+            _ => throw new InvalidOperationException($"Unknown operation id {id}")
+        };
+    }
+
+    private static int WriteOperation(string value)
+    {
+        return value switch
+        {
+            "add" => 0,
+            "multiply_base" => 1,
+            "multiply_total" => 2,
+            _ => throw new InvalidOperationException($"Unknown operation value {value}")
+        };
+    }
+
+    private static string ReadAttributeSlot(int id, int protocolVersion)
+    {
+        return (protocolVersion >= 770 ? id : id) switch
+        {
+            0 => "any",
+            1 => "main_hand",
+            2 => "off_hand",
+            3 => "hand",
+            4 => "feet",
+            5 => "legs",
+            6 => "chest",
+            7 => "head",
+            8 => "armor",
+            9 => "body",
+            10 when protocolVersion >= 770 => "saddle",
+            _ => throw new InvalidOperationException($"Unknown attribute slot id {id}")
+        };
+    }
+
+    private static int WriteAttributeSlot(string value, int protocolVersion)
+    {
+        return value switch
+        {
+            "any" => 0,
+            "main_hand" => 1,
+            "off_hand" => 2,
+            "hand" => 3,
+            "feet" => 4,
+            "legs" => 5,
+            "chest" => 6,
+            "head" => 7,
+            "armor" => 8,
+            "body" => 9,
+            "saddle" when protocolVersion >= 770 => 10,
+            _ => throw new InvalidOperationException($"Unknown attribute slot value {value}")
+        };
+    }
+
+    private static string ReadDisplayType(int id)
+    {
+        return id switch
+        {
+            0 => "default",
+            1 => "hidden",
+            2 => "override",
+            _ => throw new InvalidOperationException($"Unknown display type id {id}")
+        };
+    }
+
+    private static int WriteDisplayType(string value)
+    {
+        return value switch
+        {
+            "default" => 0,
+            "hidden" => 1,
+            "override" => 2,
+            _ => throw new InvalidOperationException($"Unknown display type value {value}")
+        };
+    }
+
+    private static string ReadConsumableAnimation(int id, int protocolVersion)
+    {
+        return id switch
+        {
+            0 => "none",
+            1 => "eat",
+            2 => "drink",
+            3 => "block",
+            4 => "bow",
+            5 => "spear",
+            6 => "crossbow",
+            7 => "spyglass",
+            8 => "toot_horn",
+            9 => "brush",
+            10 when protocolVersion >= 770 => "bundle",
+            _ => throw new InvalidOperationException($"Unknown consumable animation id {id}")
+        };
+    }
+
+    private static int WriteConsumableAnimation(string value, int protocolVersion)
+    {
+        return value switch
+        {
+            "none" => 0,
+            "eat" => 1,
+            "drink" => 2,
+            "block" => 3,
+            "bow" => 4,
+            "spear" => 5,
+            "crossbow" => 6,
+            "spyglass" => 7,
+            "toot_horn" => 8,
+            "brush" => 9,
+            "bundle" when protocolVersion >= 770 => 10,
+            _ => throw new InvalidOperationException($"Unknown consumable animation value {value}")
+        };
+    }
+
+    private static string ReadEquippableSlot(int id, int protocolVersion)
+    {
+        return id switch
+        {
+            0 => "main_hand",
+            1 => "off_hand",
+            2 => "feet",
+            3 => "legs",
+            4 => "chest",
+            5 => "head",
+            6 => "body",
+            7 when protocolVersion >= 770 => "saddle",
+            _ => throw new InvalidOperationException($"Unknown equippable slot id {id}")
+        };
+    }
+
+    private static int WriteEquippableSlot(string value, int protocolVersion)
+    {
+        return value switch
+        {
+            "main_hand" => 0,
+            "off_hand" => 1,
+            "feet" => 2,
+            "legs" => 3,
+            "chest" => 4,
+            "head" => 5,
+            "body" => 6,
+            "saddle" when protocolVersion >= 770 => 7,
+            _ => throw new InvalidOperationException($"Unknown equippable slot value {value}")
+        };
+    }
+
+    private delegate T ReadElementDelegate<T>(ref MinecraftPrimitiveReader reader);
+    private delegate void WriteElementDelegate<T>(ref MinecraftPrimitiveWriter writer, T value);
+
+    private static T[] ReadArray<T>(ref MinecraftPrimitiveReader reader, ReadElementDelegate<T> read)
+    {
+        int length = reader.ReadVarInt();
+        if (length == 0)
+        {
+            return Array.Empty<T>();
+        }
+
+        var result = new T[length];
+        for (int i = 0; i < length; i++)
+        {
+            result[i] = read(ref reader);
+        }
+
+        return result;
+    }
+
+    private static void WriteArray<T>(ref MinecraftPrimitiveWriter writer, IReadOnlyList<T> values,
+        WriteElementDelegate<T> write)
+    {
+        writer.WriteVarInt(values.Count);
+        for (int i = 0; i < values.Count; i++)
+        {
+            write(ref writer, values[i]);
+        }
+    }
+
+    private static int? ReadOptionalVarInt(ref MinecraftPrimitiveReader reader)
+        => reader.ReadBoolean() ? reader.ReadVarInt() : null;
+
+    private static int? ReadOptionalSignedInt(ref MinecraftPrimitiveReader reader)
+        => reader.ReadBoolean() ? reader.ReadSignedInt() : null;
+
+    private static float? ReadOptionalFloat(ref MinecraftPrimitiveReader reader)
+        => reader.ReadBoolean() ? reader.ReadFloat() : null;
+
+    private static bool? ReadOptionalBool(ref MinecraftPrimitiveReader reader)
+        => reader.ReadBoolean() ? reader.ReadBoolean() : null;
+
+    private static string? ReadOptionalString(ref MinecraftPrimitiveReader reader)
+        => reader.ReadBoolean() ? reader.ReadString() : null;
+
+    private static Guid? ReadOptionalUuid(ref MinecraftPrimitiveReader reader)
+        => reader.ReadBoolean() ? reader.ReadUUID() : null;
+
+    private static IDSet? ReadOptionalIdSet(ref MinecraftPrimitiveReader reader, int protocolVersion)
+        => reader.ReadBoolean() ? IDSet.Read(ref reader, protocolVersion) : null;
+
+    private static ItemSoundHolder? ReadOptionalItemSoundHolder(ref MinecraftPrimitiveReader reader, int protocolVersion)
+        => reader.ReadBoolean() ? ItemSoundHolder.Read(ref reader, protocolVersion) : null;
+
+    private static void WriteOptionalVarInt(ref MinecraftPrimitiveWriter writer, int? value)
+    {
+        if (value is null)
+        {
+            writer.WriteBoolean(false);
+        }
+        else
+        {
+            writer.WriteBoolean(true);
+            writer.WriteVarInt(value.Value);
+        }
+    }
+
+    private static void WriteOptionalSignedInt(ref MinecraftPrimitiveWriter writer, int? value)
+    {
+        if (value is null)
+        {
+            writer.WriteBoolean(false);
+        }
+        else
+        {
+            writer.WriteBoolean(true);
+            writer.WriteSignedInt(value.Value);
+        }
+    }
+
+    private static void WriteOptionalFloat(ref MinecraftPrimitiveWriter writer, float? value)
+    {
+        if (value is null)
+        {
+            writer.WriteBoolean(false);
+        }
+        else
+        {
+            writer.WriteBoolean(true);
+            writer.WriteFloat(value.Value);
+        }
+    }
+
+    private static void WriteOptionalBool(ref MinecraftPrimitiveWriter writer, bool? value)
+    {
+        if (value is null)
+        {
+            writer.WriteBoolean(false);
+        }
+        else
+        {
+            writer.WriteBoolean(true);
+            writer.WriteBoolean(value.Value);
+        }
+    }
+
+    private static void WriteOptionalString(ref MinecraftPrimitiveWriter writer, string? value)
+    {
+        if (value is null)
+        {
+            writer.WriteBoolean(false);
+        }
+        else
+        {
+            writer.WriteBoolean(true);
+            writer.WriteString(value);
+        }
+    }
+
+    private static void WriteOptionalUuid(ref MinecraftPrimitiveWriter writer, Guid? value)
+    {
+        if (value is null)
+        {
+            writer.WriteBoolean(false);
+        }
+        else
+        {
+            writer.WriteBoolean(true);
+            writer.WriteUUID(value.Value);
+        }
+    }
+
+    private static void WriteOptionalIdSet(ref MinecraftPrimitiveWriter writer, IDSet? value, int protocolVersion)
+    {
+        if (value is null)
+        {
+            writer.WriteBoolean(false);
+        }
+        else
+        {
+            writer.WriteBoolean(true);
+            value.Write(ref writer, protocolVersion);
+        }
+    }
+
+    private static void WriteOptionalItemSoundHolder(ref MinecraftPrimitiveWriter writer, ItemSoundHolder? value,
+        int protocolVersion)
+    {
+        if (value is null)
+        {
+            writer.WriteBoolean(false);
+        }
+        else
+        {
+            writer.WriteBoolean(true);
+            value.Write(ref writer, protocolVersion);
+        }
+    }
+}

--- a/src/McProtoNet.Protocol/Types/SlotComponentDependencies.cs
+++ b/src/McProtoNet.Protocol/Types/SlotComponentDependencies.cs
@@ -1,0 +1,244 @@
+using McProtoNet.Protocol.Attributes;
+using McProtoNet.Serialization;
+
+namespace McProtoNet.Protocol;
+
+[ProtocolSupport(766, MinecraftVersion.LatestProtocol)]
+public sealed partial class ArmorTrimMaterial
+{
+    public static ArmorTrimMaterial Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ArmorTrimMaterial>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ArmorTrimMaterial serialization.");
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ArmorTrimMaterial>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ArmorTrimMaterial serialization.");
+    }
+}
+
+[ProtocolSupport(766, MinecraftVersion.LatestProtocol)]
+public sealed partial class ArmorTrimPattern
+{
+    public static ArmorTrimPattern Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ArmorTrimPattern>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ArmorTrimPattern serialization.");
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ArmorTrimPattern>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ArmorTrimPattern serialization.");
+    }
+}
+
+[ProtocolSupport(766, MinecraftVersion.LatestProtocol)]
+public sealed partial class BannerPatternLayer
+{
+    public static BannerPatternLayer Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<BannerPatternLayer>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement BannerPatternLayer serialization.");
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<BannerPatternLayer>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement BannerPatternLayer serialization.");
+    }
+}
+
+[ProtocolSupport(766, MinecraftVersion.LatestProtocol)]
+public sealed partial class EntityMetadataPaintingVariant
+{
+    public static EntityMetadataPaintingVariant Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<EntityMetadataPaintingVariant>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement EntityMetadataPaintingVariant serialization.");
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<EntityMetadataPaintingVariant>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement EntityMetadataPaintingVariant serialization.");
+    }
+}
+
+[ProtocolSupport(766, MinecraftVersion.LatestProtocol)]
+public sealed partial class IDSet
+{
+    public static IDSet Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<IDSet>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement IDSet serialization.");
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<IDSet>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement IDSet serialization.");
+    }
+}
+
+[ProtocolSupport(766, MinecraftVersion.LatestProtocol)]
+public sealed partial class InstrumentData
+{
+    public static InstrumentData Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<InstrumentData>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement InstrumentData serialization.");
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<InstrumentData>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement InstrumentData serialization.");
+    }
+}
+
+[ProtocolSupport(766, MinecraftVersion.LatestProtocol)]
+public sealed partial class ItemBlockPredicate
+{
+    public static ItemBlockPredicate Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ItemBlockPredicate>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ItemBlockPredicate serialization.");
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ItemBlockPredicate>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ItemBlockPredicate serialization.");
+    }
+}
+
+[ProtocolSupport(766, MinecraftVersion.LatestProtocol)]
+public sealed partial class ItemBookPage
+{
+    public static ItemBookPage Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ItemBookPage>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ItemBookPage serialization.");
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ItemBookPage>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ItemBookPage serialization.");
+    }
+}
+
+[ProtocolSupport(766, MinecraftVersion.LatestProtocol)]
+public sealed partial class ItemConsumeEffect
+{
+    public static ItemConsumeEffect Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ItemConsumeEffect>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ItemConsumeEffect serialization.");
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ItemConsumeEffect>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ItemConsumeEffect serialization.");
+    }
+}
+
+[ProtocolSupport(766, MinecraftVersion.LatestProtocol)]
+public sealed partial class ItemFireworkExplosion
+{
+    public static ItemFireworkExplosion Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ItemFireworkExplosion>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ItemFireworkExplosion serialization.");
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ItemFireworkExplosion>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ItemFireworkExplosion serialization.");
+    }
+}
+
+[ProtocolSupport(766, MinecraftVersion.LatestProtocol)]
+public sealed partial class ItemPotionEffect
+{
+    public static ItemPotionEffect Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ItemPotionEffect>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ItemPotionEffect serialization.");
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ItemPotionEffect>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ItemPotionEffect serialization.");
+    }
+}
+
+[ProtocolSupport(766, MinecraftVersion.LatestProtocol)]
+public sealed partial class ItemSoundHolder
+{
+    public static ItemSoundHolder Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ItemSoundHolder>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ItemSoundHolder serialization.");
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ItemSoundHolder>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ItemSoundHolder serialization.");
+    }
+}
+
+[ProtocolSupport(766, MinecraftVersion.LatestProtocol)]
+public sealed partial class ItemWrittenBookPage
+{
+    public static ItemWrittenBookPage Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ItemWrittenBookPage>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ItemWrittenBookPage serialization.");
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ItemWrittenBookPage>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ItemWrittenBookPage serialization.");
+    }
+}
+
+[ProtocolSupport(766, MinecraftVersion.LatestProtocol)]
+public sealed partial class JukeboxSongData
+{
+    public static JukeboxSongData Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<JukeboxSongData>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement JukeboxSongData serialization.");
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<JukeboxSongData>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement JukeboxSongData serialization.");
+    }
+}
+
+[ProtocolSupport(770, MinecraftVersion.LatestProtocol)]
+public sealed partial class ByteArray
+{
+    public static ByteArray Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ByteArray>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ByteArray serialization.");
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<ByteArray>(protocolVersion);
+        throw new NotImplementedException("TODO: Implement ByteArray serialization.");
+    }
+}

--- a/src/McProtoNet.Protocol/Types/SlotComponentType.cs
+++ b/src/McProtoNet.Protocol/Types/SlotComponentType.cs
@@ -1,0 +1,755 @@
+using McProtoNet.Protocol.Attributes;
+using McProtoNet.Serialization;
+
+namespace McProtoNet.Protocol;
+
+[ProtocolSupport(766, MinecraftVersion.LatestProtocol)]
+public enum SlotComponentType
+{
+    AttributeModifiers,
+    AxolotlVariant,
+    BannerPatterns,
+    BaseColor,
+    Bees,
+    BlockEntityData,
+    BlockState,
+    BlocksAttacks,
+    BreakSound,
+    BucketEntityData,
+    BundleContents,
+    CanBreak,
+    CanPlaceOn,
+    CatCollar,
+    CatVariant,
+    ChargedProjectiles,
+    ChickenVariant,
+    Consumable,
+    Container,
+    ContainerLoot,
+    CowVariant,
+    CreativeSlotLock,
+    CustomData,
+    CustomModelData,
+    CustomName,
+    Damage,
+    DamageResistant,
+    DeathProtection,
+    DebugStickState,
+    DyedColor,
+    Enchantable,
+    EnchantmentGlintOverride,
+    Enchantments,
+    EntityData,
+    Equippable,
+    FireResistant,
+    FireworkExplosion,
+    Fireworks,
+    Food,
+    FoxVariant,
+    FrogVariant,
+    Glider,
+    HideAdditionalTooltip,
+    HideTooltip,
+    HorseVariant,
+    Instrument,
+    IntangibleProjectile,
+    ItemModel,
+    ItemName,
+    JukeboxPlayable,
+    LlamaVariant,
+    Lock,
+    LodestoneTracker,
+    Lore,
+    MapColor,
+    MapDecorations,
+    MapId,
+    MapPostProcessing,
+    MaxDamage,
+    MaxStackSize,
+    MooshroomVariant,
+    NoteBlockSound,
+    OminousBottleAmplifier,
+    PaintingVariant,
+    ParrotVariant,
+    PigVariant,
+    PotDecorations,
+    PotionContents,
+    PotionDurationScale,
+    Profile,
+    ProvidesBannerPatterns,
+    ProvidesTrimMaterial,
+    RabbitVariant,
+    Rarity,
+    Recipes,
+    RepairCost,
+    Repairable,
+    SalmonSize,
+    SheepColor,
+    ShulkerColor,
+    StoredEnchantments,
+    SuspiciousStewEffects,
+    Tool,
+    TooltipDisplay,
+    TooltipStyle,
+    Trim,
+    TropicalFishBaseColor,
+    TropicalFishPattern,
+    TropicalFishPatternColor,
+    Unbreakable,
+    UseCooldown,
+    UseRemainder,
+    VillagerVariant,
+    Weapon,
+    WolfCollar,
+    WolfSoundVariant,
+    WolfVariant,
+    WritableBookContent,
+    WrittenBookContent
+}
+
+public static class SlotComponentTypeExtensions
+{
+    public static SlotComponentType Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<SlotComponentType>(protocolVersion);
+        int id = reader.ReadVarInt();
+        return protocolVersion switch
+        {
+            766 => FromId766(id, protocolVersion),
+            767 => FromId767(id, protocolVersion),
+            >= 768 and <= 769 => FromId768To769(id, protocolVersion),
+            >= 770 and <= 772 => FromId770To772(id, protocolVersion),
+            _ => throw new InvalidOperationException($"Unknown SlotComponentType id {id} for protocol {protocolVersion}.")
+        };
+    }
+
+    public static void Write(this SlotComponentType value, ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<SlotComponentType>(protocolVersion);
+        int id = protocolVersion switch
+        {
+            766 => ToId766(value, protocolVersion),
+            767 => ToId767(value, protocolVersion),
+            >= 768 and <= 769 => ToId768To769(value, protocolVersion),
+            >= 770 and <= 772 => ToId770To772(value, protocolVersion),
+            _ => throw new InvalidOperationException($"Unknown SlotComponentType {value} for protocol {protocolVersion}.")
+        };
+        writer.WriteVarInt(id);
+    }
+
+    private static SlotComponentType FromId766(int id, int protocolVersion)
+    {
+        switch (id)
+        {
+            case 0: return SlotComponentType.CustomData;
+            case 1: return SlotComponentType.MaxStackSize;
+            case 2: return SlotComponentType.MaxDamage;
+            case 3: return SlotComponentType.Damage;
+            case 4: return SlotComponentType.Unbreakable;
+            case 5: return SlotComponentType.CustomName;
+            case 6: return SlotComponentType.ItemName;
+            case 7: return SlotComponentType.Lore;
+            case 8: return SlotComponentType.Rarity;
+            case 9: return SlotComponentType.Enchantments;
+            case 10: return SlotComponentType.CanPlaceOn;
+            case 11: return SlotComponentType.CanBreak;
+            case 12: return SlotComponentType.AttributeModifiers;
+            case 13: return SlotComponentType.CustomModelData;
+            case 14: return SlotComponentType.HideAdditionalTooltip;
+            case 15: return SlotComponentType.HideTooltip;
+            case 16: return SlotComponentType.RepairCost;
+            case 17: return SlotComponentType.CreativeSlotLock;
+            case 18: return SlotComponentType.EnchantmentGlintOverride;
+            case 19: return SlotComponentType.IntangibleProjectile;
+            case 20: return SlotComponentType.Food;
+            case 21: return SlotComponentType.FireResistant;
+            case 22: return SlotComponentType.Tool;
+            case 23: return SlotComponentType.StoredEnchantments;
+            case 24: return SlotComponentType.DyedColor;
+            case 25: return SlotComponentType.MapColor;
+            case 26: return SlotComponentType.MapId;
+            case 27: return SlotComponentType.MapDecorations;
+            case 28: return SlotComponentType.MapPostProcessing;
+            case 29: return SlotComponentType.ChargedProjectiles;
+            case 30: return SlotComponentType.BundleContents;
+            case 31: return SlotComponentType.PotionContents;
+            case 32: return SlotComponentType.SuspiciousStewEffects;
+            case 33: return SlotComponentType.WritableBookContent;
+            case 34: return SlotComponentType.WrittenBookContent;
+            case 35: return SlotComponentType.Trim;
+            case 36: return SlotComponentType.DebugStickState;
+            case 37: return SlotComponentType.EntityData;
+            case 38: return SlotComponentType.BucketEntityData;
+            case 39: return SlotComponentType.BlockEntityData;
+            case 40: return SlotComponentType.Instrument;
+            case 41: return SlotComponentType.OminousBottleAmplifier;
+            case 42: return SlotComponentType.Recipes;
+            case 43: return SlotComponentType.LodestoneTracker;
+            case 44: return SlotComponentType.FireworkExplosion;
+            case 45: return SlotComponentType.Fireworks;
+            case 46: return SlotComponentType.Profile;
+            case 47: return SlotComponentType.NoteBlockSound;
+            case 48: return SlotComponentType.BannerPatterns;
+            case 49: return SlotComponentType.BaseColor;
+            case 50: return SlotComponentType.PotDecorations;
+            case 51: return SlotComponentType.Container;
+            case 52: return SlotComponentType.BlockState;
+            case 53: return SlotComponentType.Bees;
+            case 54: return SlotComponentType.Lock;
+            case 55: return SlotComponentType.ContainerLoot;
+            default: throw new InvalidOperationException($"Unknown SlotComponentType id {id} for protocol {protocolVersion}.");
+        }
+    }
+
+    private static SlotComponentType FromId767(int id, int protocolVersion)
+    {
+        switch (id)
+        {
+            case 0: return SlotComponentType.CustomData;
+            case 1: return SlotComponentType.MaxStackSize;
+            case 2: return SlotComponentType.MaxDamage;
+            case 3: return SlotComponentType.Damage;
+            case 4: return SlotComponentType.Unbreakable;
+            case 5: return SlotComponentType.CustomName;
+            case 6: return SlotComponentType.ItemName;
+            case 7: return SlotComponentType.Lore;
+            case 8: return SlotComponentType.Rarity;
+            case 9: return SlotComponentType.Enchantments;
+            case 10: return SlotComponentType.CanPlaceOn;
+            case 11: return SlotComponentType.CanBreak;
+            case 12: return SlotComponentType.AttributeModifiers;
+            case 13: return SlotComponentType.CustomModelData;
+            case 14: return SlotComponentType.HideAdditionalTooltip;
+            case 15: return SlotComponentType.HideTooltip;
+            case 16: return SlotComponentType.RepairCost;
+            case 17: return SlotComponentType.CreativeSlotLock;
+            case 18: return SlotComponentType.EnchantmentGlintOverride;
+            case 19: return SlotComponentType.IntangibleProjectile;
+            case 20: return SlotComponentType.Food;
+            case 21: return SlotComponentType.FireResistant;
+            case 22: return SlotComponentType.Tool;
+            case 23: return SlotComponentType.StoredEnchantments;
+            case 24: return SlotComponentType.DyedColor;
+            case 25: return SlotComponentType.MapColor;
+            case 26: return SlotComponentType.MapId;
+            case 27: return SlotComponentType.MapDecorations;
+            case 28: return SlotComponentType.MapPostProcessing;
+            case 29: return SlotComponentType.ChargedProjectiles;
+            case 30: return SlotComponentType.BundleContents;
+            case 31: return SlotComponentType.PotionContents;
+            case 32: return SlotComponentType.SuspiciousStewEffects;
+            case 33: return SlotComponentType.WritableBookContent;
+            case 34: return SlotComponentType.WrittenBookContent;
+            case 35: return SlotComponentType.Trim;
+            case 36: return SlotComponentType.DebugStickState;
+            case 37: return SlotComponentType.EntityData;
+            case 38: return SlotComponentType.BucketEntityData;
+            case 39: return SlotComponentType.BlockEntityData;
+            case 40: return SlotComponentType.Instrument;
+            case 41: return SlotComponentType.OminousBottleAmplifier;
+            case 42: return SlotComponentType.JukeboxPlayable;
+            case 43: return SlotComponentType.Recipes;
+            case 44: return SlotComponentType.LodestoneTracker;
+            case 45: return SlotComponentType.FireworkExplosion;
+            case 46: return SlotComponentType.Fireworks;
+            case 47: return SlotComponentType.Profile;
+            case 48: return SlotComponentType.NoteBlockSound;
+            case 49: return SlotComponentType.BannerPatterns;
+            case 50: return SlotComponentType.BaseColor;
+            case 51: return SlotComponentType.PotDecorations;
+            case 52: return SlotComponentType.Container;
+            case 53: return SlotComponentType.BlockState;
+            case 54: return SlotComponentType.Bees;
+            case 55: return SlotComponentType.Lock;
+            case 56: return SlotComponentType.ContainerLoot;
+            default: throw new InvalidOperationException($"Unknown SlotComponentType id {id} for protocol {protocolVersion}.");
+        }
+    }
+
+    private static SlotComponentType FromId768To769(int id, int protocolVersion)
+    {
+        switch (id)
+        {
+            case 0: return SlotComponentType.CustomData;
+            case 1: return SlotComponentType.MaxStackSize;
+            case 2: return SlotComponentType.MaxDamage;
+            case 3: return SlotComponentType.Damage;
+            case 4: return SlotComponentType.Unbreakable;
+            case 5: return SlotComponentType.CustomName;
+            case 6: return SlotComponentType.ItemName;
+            case 7: return SlotComponentType.ItemModel;
+            case 8: return SlotComponentType.Lore;
+            case 9: return SlotComponentType.Rarity;
+            case 10: return SlotComponentType.Enchantments;
+            case 11: return SlotComponentType.CanPlaceOn;
+            case 12: return SlotComponentType.CanBreak;
+            case 13: return SlotComponentType.AttributeModifiers;
+            case 14: return SlotComponentType.CustomModelData;
+            case 15: return SlotComponentType.HideAdditionalTooltip;
+            case 16: return SlotComponentType.HideTooltip;
+            case 17: return SlotComponentType.RepairCost;
+            case 18: return SlotComponentType.CreativeSlotLock;
+            case 19: return SlotComponentType.EnchantmentGlintOverride;
+            case 20: return SlotComponentType.IntangibleProjectile;
+            case 21: return SlotComponentType.Food;
+            case 22: return SlotComponentType.Consumable;
+            case 23: return SlotComponentType.UseRemainder;
+            case 24: return SlotComponentType.UseCooldown;
+            case 25: return SlotComponentType.DamageResistant;
+            case 26: return SlotComponentType.Tool;
+            case 27: return SlotComponentType.Enchantable;
+            case 28: return SlotComponentType.Equippable;
+            case 29: return SlotComponentType.Repairable;
+            case 30: return SlotComponentType.Glider;
+            case 31: return SlotComponentType.TooltipStyle;
+            case 32: return SlotComponentType.DeathProtection;
+            case 33: return SlotComponentType.StoredEnchantments;
+            case 34: return SlotComponentType.DyedColor;
+            case 35: return SlotComponentType.MapColor;
+            case 36: return SlotComponentType.MapId;
+            case 37: return SlotComponentType.MapDecorations;
+            case 38: return SlotComponentType.MapPostProcessing;
+            case 39: return SlotComponentType.ChargedProjectiles;
+            case 40: return SlotComponentType.BundleContents;
+            case 41: return SlotComponentType.PotionContents;
+            case 42: return SlotComponentType.SuspiciousStewEffects;
+            case 43: return SlotComponentType.WritableBookContent;
+            case 44: return SlotComponentType.WrittenBookContent;
+            case 45: return SlotComponentType.Trim;
+            case 46: return SlotComponentType.DebugStickState;
+            case 47: return SlotComponentType.EntityData;
+            case 48: return SlotComponentType.BucketEntityData;
+            case 49: return SlotComponentType.BlockEntityData;
+            case 50: return SlotComponentType.Instrument;
+            case 51: return SlotComponentType.OminousBottleAmplifier;
+            case 52: return SlotComponentType.JukeboxPlayable;
+            case 53: return SlotComponentType.Recipes;
+            case 54: return SlotComponentType.LodestoneTracker;
+            case 55: return SlotComponentType.FireworkExplosion;
+            case 56: return SlotComponentType.Fireworks;
+            case 57: return SlotComponentType.Profile;
+            case 58: return SlotComponentType.NoteBlockSound;
+            case 59: return SlotComponentType.BannerPatterns;
+            case 60: return SlotComponentType.BaseColor;
+            case 61: return SlotComponentType.PotDecorations;
+            case 62: return SlotComponentType.Container;
+            case 63: return SlotComponentType.BlockState;
+            case 64: return SlotComponentType.Bees;
+            case 65: return SlotComponentType.Lock;
+            case 66: return SlotComponentType.ContainerLoot;
+            default: throw new InvalidOperationException($"Unknown SlotComponentType id {id} for protocol {protocolVersion}.");
+        }
+    }
+
+    private static SlotComponentType FromId770To772(int id, int protocolVersion)
+    {
+        switch (id)
+        {
+            case 0: return SlotComponentType.CustomData;
+            case 1: return SlotComponentType.MaxStackSize;
+            case 2: return SlotComponentType.MaxDamage;
+            case 3: return SlotComponentType.Damage;
+            case 4: return SlotComponentType.Unbreakable;
+            case 5: return SlotComponentType.CustomName;
+            case 6: return SlotComponentType.ItemName;
+            case 7: return SlotComponentType.ItemModel;
+            case 8: return SlotComponentType.Lore;
+            case 9: return SlotComponentType.Rarity;
+            case 10: return SlotComponentType.Enchantments;
+            case 11: return SlotComponentType.CanPlaceOn;
+            case 12: return SlotComponentType.CanBreak;
+            case 13: return SlotComponentType.AttributeModifiers;
+            case 14: return SlotComponentType.CustomModelData;
+            case 15: return SlotComponentType.TooltipDisplay;
+            case 16: return SlotComponentType.RepairCost;
+            case 17: return SlotComponentType.CreativeSlotLock;
+            case 18: return SlotComponentType.EnchantmentGlintOverride;
+            case 19: return SlotComponentType.IntangibleProjectile;
+            case 20: return SlotComponentType.Food;
+            case 21: return SlotComponentType.Consumable;
+            case 22: return SlotComponentType.UseRemainder;
+            case 23: return SlotComponentType.UseCooldown;
+            case 24: return SlotComponentType.DamageResistant;
+            case 25: return SlotComponentType.Tool;
+            case 26: return SlotComponentType.Weapon;
+            case 27: return SlotComponentType.Enchantable;
+            case 28: return SlotComponentType.Equippable;
+            case 29: return SlotComponentType.Repairable;
+            case 30: return SlotComponentType.Glider;
+            case 31: return SlotComponentType.TooltipStyle;
+            case 32: return SlotComponentType.DeathProtection;
+            case 33: return SlotComponentType.BlocksAttacks;
+            case 34: return SlotComponentType.StoredEnchantments;
+            case 35: return SlotComponentType.DyedColor;
+            case 36: return SlotComponentType.MapColor;
+            case 37: return SlotComponentType.MapId;
+            case 38: return SlotComponentType.MapDecorations;
+            case 39: return SlotComponentType.MapPostProcessing;
+            case 40: return SlotComponentType.PotionDurationScale;
+            case 41: return SlotComponentType.ChargedProjectiles;
+            case 42: return SlotComponentType.BundleContents;
+            case 43: return SlotComponentType.PotionContents;
+            case 44: return SlotComponentType.SuspiciousStewEffects;
+            case 45: return SlotComponentType.WritableBookContent;
+            case 46: return SlotComponentType.WrittenBookContent;
+            case 47: return SlotComponentType.Trim;
+            case 48: return SlotComponentType.DebugStickState;
+            case 49: return SlotComponentType.EntityData;
+            case 50: return SlotComponentType.BucketEntityData;
+            case 51: return SlotComponentType.BlockEntityData;
+            case 52: return SlotComponentType.Instrument;
+            case 53: return SlotComponentType.ProvidesTrimMaterial;
+            case 54: return SlotComponentType.OminousBottleAmplifier;
+            case 55: return SlotComponentType.JukeboxPlayable;
+            case 56: return SlotComponentType.ProvidesBannerPatterns;
+            case 57: return SlotComponentType.Recipes;
+            case 58: return SlotComponentType.LodestoneTracker;
+            case 59: return SlotComponentType.FireworkExplosion;
+            case 60: return SlotComponentType.Fireworks;
+            case 61: return SlotComponentType.Profile;
+            case 62: return SlotComponentType.NoteBlockSound;
+            case 63: return SlotComponentType.BannerPatterns;
+            case 64: return SlotComponentType.BaseColor;
+            case 65: return SlotComponentType.PotDecorations;
+            case 66: return SlotComponentType.Container;
+            case 67: return SlotComponentType.BlockState;
+            case 68: return SlotComponentType.Bees;
+            case 69: return SlotComponentType.Lock;
+            case 70: return SlotComponentType.ContainerLoot;
+            case 71: return SlotComponentType.BreakSound;
+            case 72: return SlotComponentType.VillagerVariant;
+            case 73: return SlotComponentType.WolfVariant;
+            case 74: return SlotComponentType.WolfSoundVariant;
+            case 75: return SlotComponentType.WolfCollar;
+            case 76: return SlotComponentType.FoxVariant;
+            case 77: return SlotComponentType.SalmonSize;
+            case 78: return SlotComponentType.ParrotVariant;
+            case 79: return SlotComponentType.TropicalFishPattern;
+            case 80: return SlotComponentType.TropicalFishBaseColor;
+            case 81: return SlotComponentType.TropicalFishPatternColor;
+            case 82: return SlotComponentType.MooshroomVariant;
+            case 83: return SlotComponentType.RabbitVariant;
+            case 84: return SlotComponentType.PigVariant;
+            case 85: return SlotComponentType.CowVariant;
+            case 86: return SlotComponentType.ChickenVariant;
+            case 87: return SlotComponentType.FrogVariant;
+            case 88: return SlotComponentType.HorseVariant;
+            case 89: return SlotComponentType.PaintingVariant;
+            case 90: return SlotComponentType.LlamaVariant;
+            case 91: return SlotComponentType.AxolotlVariant;
+            case 92: return SlotComponentType.CatVariant;
+            case 93: return SlotComponentType.CatCollar;
+            case 94: return SlotComponentType.SheepColor;
+            case 95: return SlotComponentType.ShulkerColor;
+            default: throw new InvalidOperationException($"Unknown SlotComponentType id {id} for protocol {protocolVersion}.");
+        }
+    }
+
+    private static int ToId766(SlotComponentType value, int protocolVersion)
+    {
+        return value switch
+        {
+            SlotComponentType.CustomData => 0,
+            SlotComponentType.MaxStackSize => 1,
+            SlotComponentType.MaxDamage => 2,
+            SlotComponentType.Damage => 3,
+            SlotComponentType.Unbreakable => 4,
+            SlotComponentType.CustomName => 5,
+            SlotComponentType.ItemName => 6,
+            SlotComponentType.Lore => 7,
+            SlotComponentType.Rarity => 8,
+            SlotComponentType.Enchantments => 9,
+            SlotComponentType.CanPlaceOn => 10,
+            SlotComponentType.CanBreak => 11,
+            SlotComponentType.AttributeModifiers => 12,
+            SlotComponentType.CustomModelData => 13,
+            SlotComponentType.HideAdditionalTooltip => 14,
+            SlotComponentType.HideTooltip => 15,
+            SlotComponentType.RepairCost => 16,
+            SlotComponentType.CreativeSlotLock => 17,
+            SlotComponentType.EnchantmentGlintOverride => 18,
+            SlotComponentType.IntangibleProjectile => 19,
+            SlotComponentType.Food => 20,
+            SlotComponentType.FireResistant => 21,
+            SlotComponentType.Tool => 22,
+            SlotComponentType.StoredEnchantments => 23,
+            SlotComponentType.DyedColor => 24,
+            SlotComponentType.MapColor => 25,
+            SlotComponentType.MapId => 26,
+            SlotComponentType.MapDecorations => 27,
+            SlotComponentType.MapPostProcessing => 28,
+            SlotComponentType.ChargedProjectiles => 29,
+            SlotComponentType.BundleContents => 30,
+            SlotComponentType.PotionContents => 31,
+            SlotComponentType.SuspiciousStewEffects => 32,
+            SlotComponentType.WritableBookContent => 33,
+            SlotComponentType.WrittenBookContent => 34,
+            SlotComponentType.Trim => 35,
+            SlotComponentType.DebugStickState => 36,
+            SlotComponentType.EntityData => 37,
+            SlotComponentType.BucketEntityData => 38,
+            SlotComponentType.BlockEntityData => 39,
+            SlotComponentType.Instrument => 40,
+            SlotComponentType.OminousBottleAmplifier => 41,
+            SlotComponentType.Recipes => 42,
+            SlotComponentType.LodestoneTracker => 43,
+            SlotComponentType.FireworkExplosion => 44,
+            SlotComponentType.Fireworks => 45,
+            SlotComponentType.Profile => 46,
+            SlotComponentType.NoteBlockSound => 47,
+            SlotComponentType.BannerPatterns => 48,
+            SlotComponentType.BaseColor => 49,
+            SlotComponentType.PotDecorations => 50,
+            SlotComponentType.Container => 51,
+            SlotComponentType.BlockState => 52,
+            SlotComponentType.Bees => 53,
+            SlotComponentType.Lock => 54,
+            SlotComponentType.ContainerLoot => 55,
+            _ => throw new InvalidOperationException($"Unknown SlotComponentType {value} for protocol {protocolVersion}.")
+        };
+    }
+
+    private static int ToId767(SlotComponentType value, int protocolVersion)
+    {
+        return value switch
+        {
+            SlotComponentType.CustomData => 0,
+            SlotComponentType.MaxStackSize => 1,
+            SlotComponentType.MaxDamage => 2,
+            SlotComponentType.Damage => 3,
+            SlotComponentType.Unbreakable => 4,
+            SlotComponentType.CustomName => 5,
+            SlotComponentType.ItemName => 6,
+            SlotComponentType.Lore => 7,
+            SlotComponentType.Rarity => 8,
+            SlotComponentType.Enchantments => 9,
+            SlotComponentType.CanPlaceOn => 10,
+            SlotComponentType.CanBreak => 11,
+            SlotComponentType.AttributeModifiers => 12,
+            SlotComponentType.CustomModelData => 13,
+            SlotComponentType.HideAdditionalTooltip => 14,
+            SlotComponentType.HideTooltip => 15,
+            SlotComponentType.RepairCost => 16,
+            SlotComponentType.CreativeSlotLock => 17,
+            SlotComponentType.EnchantmentGlintOverride => 18,
+            SlotComponentType.IntangibleProjectile => 19,
+            SlotComponentType.Food => 20,
+            SlotComponentType.FireResistant => 21,
+            SlotComponentType.Tool => 22,
+            SlotComponentType.StoredEnchantments => 23,
+            SlotComponentType.DyedColor => 24,
+            SlotComponentType.MapColor => 25,
+            SlotComponentType.MapId => 26,
+            SlotComponentType.MapDecorations => 27,
+            SlotComponentType.MapPostProcessing => 28,
+            SlotComponentType.ChargedProjectiles => 29,
+            SlotComponentType.BundleContents => 30,
+            SlotComponentType.PotionContents => 31,
+            SlotComponentType.SuspiciousStewEffects => 32,
+            SlotComponentType.WritableBookContent => 33,
+            SlotComponentType.WrittenBookContent => 34,
+            SlotComponentType.Trim => 35,
+            SlotComponentType.DebugStickState => 36,
+            SlotComponentType.EntityData => 37,
+            SlotComponentType.BucketEntityData => 38,
+            SlotComponentType.BlockEntityData => 39,
+            SlotComponentType.Instrument => 40,
+            SlotComponentType.OminousBottleAmplifier => 41,
+            SlotComponentType.JukeboxPlayable => 42,
+            SlotComponentType.Recipes => 43,
+            SlotComponentType.LodestoneTracker => 44,
+            SlotComponentType.FireworkExplosion => 45,
+            SlotComponentType.Fireworks => 46,
+            SlotComponentType.Profile => 47,
+            SlotComponentType.NoteBlockSound => 48,
+            SlotComponentType.BannerPatterns => 49,
+            SlotComponentType.BaseColor => 50,
+            SlotComponentType.PotDecorations => 51,
+            SlotComponentType.Container => 52,
+            SlotComponentType.BlockState => 53,
+            SlotComponentType.Bees => 54,
+            SlotComponentType.Lock => 55,
+            SlotComponentType.ContainerLoot => 56,
+            _ => throw new InvalidOperationException($"Unknown SlotComponentType {value} for protocol {protocolVersion}.")
+        };
+    }
+
+    private static int ToId768To769(SlotComponentType value, int protocolVersion)
+    {
+        return value switch
+        {
+            SlotComponentType.CustomData => 0,
+            SlotComponentType.MaxStackSize => 1,
+            SlotComponentType.MaxDamage => 2,
+            SlotComponentType.Damage => 3,
+            SlotComponentType.Unbreakable => 4,
+            SlotComponentType.CustomName => 5,
+            SlotComponentType.ItemName => 6,
+            SlotComponentType.ItemModel => 7,
+            SlotComponentType.Lore => 8,
+            SlotComponentType.Rarity => 9,
+            SlotComponentType.Enchantments => 10,
+            SlotComponentType.CanPlaceOn => 11,
+            SlotComponentType.CanBreak => 12,
+            SlotComponentType.AttributeModifiers => 13,
+            SlotComponentType.CustomModelData => 14,
+            SlotComponentType.HideAdditionalTooltip => 15,
+            SlotComponentType.HideTooltip => 16,
+            SlotComponentType.RepairCost => 17,
+            SlotComponentType.CreativeSlotLock => 18,
+            SlotComponentType.EnchantmentGlintOverride => 19,
+            SlotComponentType.IntangibleProjectile => 20,
+            SlotComponentType.Food => 21,
+            SlotComponentType.Consumable => 22,
+            SlotComponentType.UseRemainder => 23,
+            SlotComponentType.UseCooldown => 24,
+            SlotComponentType.DamageResistant => 25,
+            SlotComponentType.Tool => 26,
+            SlotComponentType.Enchantable => 27,
+            SlotComponentType.Equippable => 28,
+            SlotComponentType.Repairable => 29,
+            SlotComponentType.Glider => 30,
+            SlotComponentType.TooltipStyle => 31,
+            SlotComponentType.DeathProtection => 32,
+            SlotComponentType.StoredEnchantments => 33,
+            SlotComponentType.DyedColor => 34,
+            SlotComponentType.MapColor => 35,
+            SlotComponentType.MapId => 36,
+            SlotComponentType.MapDecorations => 37,
+            SlotComponentType.MapPostProcessing => 38,
+            SlotComponentType.ChargedProjectiles => 39,
+            SlotComponentType.BundleContents => 40,
+            SlotComponentType.PotionContents => 41,
+            SlotComponentType.SuspiciousStewEffects => 42,
+            SlotComponentType.WritableBookContent => 43,
+            SlotComponentType.WrittenBookContent => 44,
+            SlotComponentType.Trim => 45,
+            SlotComponentType.DebugStickState => 46,
+            SlotComponentType.EntityData => 47,
+            SlotComponentType.BucketEntityData => 48,
+            SlotComponentType.BlockEntityData => 49,
+            SlotComponentType.Instrument => 50,
+            SlotComponentType.OminousBottleAmplifier => 51,
+            SlotComponentType.JukeboxPlayable => 52,
+            SlotComponentType.Recipes => 53,
+            SlotComponentType.LodestoneTracker => 54,
+            SlotComponentType.FireworkExplosion => 55,
+            SlotComponentType.Fireworks => 56,
+            SlotComponentType.Profile => 57,
+            SlotComponentType.NoteBlockSound => 58,
+            SlotComponentType.BannerPatterns => 59,
+            SlotComponentType.BaseColor => 60,
+            SlotComponentType.PotDecorations => 61,
+            SlotComponentType.Container => 62,
+            SlotComponentType.BlockState => 63,
+            SlotComponentType.Bees => 64,
+            SlotComponentType.Lock => 65,
+            SlotComponentType.ContainerLoot => 66,
+            _ => throw new InvalidOperationException($"Unknown SlotComponentType {value} for protocol {protocolVersion}.")
+        };
+    }
+
+    private static int ToId770To772(SlotComponentType value, int protocolVersion)
+    {
+        return value switch
+        {
+            SlotComponentType.CustomData => 0,
+            SlotComponentType.MaxStackSize => 1,
+            SlotComponentType.MaxDamage => 2,
+            SlotComponentType.Damage => 3,
+            SlotComponentType.Unbreakable => 4,
+            SlotComponentType.CustomName => 5,
+            SlotComponentType.ItemName => 6,
+            SlotComponentType.ItemModel => 7,
+            SlotComponentType.Lore => 8,
+            SlotComponentType.Rarity => 9,
+            SlotComponentType.Enchantments => 10,
+            SlotComponentType.CanPlaceOn => 11,
+            SlotComponentType.CanBreak => 12,
+            SlotComponentType.AttributeModifiers => 13,
+            SlotComponentType.CustomModelData => 14,
+            SlotComponentType.TooltipDisplay => 15,
+            SlotComponentType.RepairCost => 16,
+            SlotComponentType.CreativeSlotLock => 17,
+            SlotComponentType.EnchantmentGlintOverride => 18,
+            SlotComponentType.IntangibleProjectile => 19,
+            SlotComponentType.Food => 20,
+            SlotComponentType.Consumable => 21,
+            SlotComponentType.UseRemainder => 22,
+            SlotComponentType.UseCooldown => 23,
+            SlotComponentType.DamageResistant => 24,
+            SlotComponentType.Tool => 25,
+            SlotComponentType.Weapon => 26,
+            SlotComponentType.Enchantable => 27,
+            SlotComponentType.Equippable => 28,
+            SlotComponentType.Repairable => 29,
+            SlotComponentType.Glider => 30,
+            SlotComponentType.TooltipStyle => 31,
+            SlotComponentType.DeathProtection => 32,
+            SlotComponentType.BlocksAttacks => 33,
+            SlotComponentType.StoredEnchantments => 34,
+            SlotComponentType.DyedColor => 35,
+            SlotComponentType.MapColor => 36,
+            SlotComponentType.MapId => 37,
+            SlotComponentType.MapDecorations => 38,
+            SlotComponentType.MapPostProcessing => 39,
+            SlotComponentType.PotionDurationScale => 40,
+            SlotComponentType.ChargedProjectiles => 41,
+            SlotComponentType.BundleContents => 42,
+            SlotComponentType.PotionContents => 43,
+            SlotComponentType.SuspiciousStewEffects => 44,
+            SlotComponentType.WritableBookContent => 45,
+            SlotComponentType.WrittenBookContent => 46,
+            SlotComponentType.Trim => 47,
+            SlotComponentType.DebugStickState => 48,
+            SlotComponentType.EntityData => 49,
+            SlotComponentType.BucketEntityData => 50,
+            SlotComponentType.BlockEntityData => 51,
+            SlotComponentType.Instrument => 52,
+            SlotComponentType.ProvidesTrimMaterial => 53,
+            SlotComponentType.OminousBottleAmplifier => 54,
+            SlotComponentType.JukeboxPlayable => 55,
+            SlotComponentType.ProvidesBannerPatterns => 56,
+            SlotComponentType.Recipes => 57,
+            SlotComponentType.LodestoneTracker => 58,
+            SlotComponentType.FireworkExplosion => 59,
+            SlotComponentType.Fireworks => 60,
+            SlotComponentType.Profile => 61,
+            SlotComponentType.NoteBlockSound => 62,
+            SlotComponentType.BannerPatterns => 63,
+            SlotComponentType.BaseColor => 64,
+            SlotComponentType.PotDecorations => 65,
+            SlotComponentType.Container => 66,
+            SlotComponentType.BlockState => 67,
+            SlotComponentType.Bees => 68,
+            SlotComponentType.Lock => 69,
+            SlotComponentType.ContainerLoot => 70,
+            SlotComponentType.BreakSound => 71,
+            SlotComponentType.VillagerVariant => 72,
+            SlotComponentType.WolfVariant => 73,
+            SlotComponentType.WolfSoundVariant => 74,
+            SlotComponentType.WolfCollar => 75,
+            SlotComponentType.FoxVariant => 76,
+            SlotComponentType.SalmonSize => 77,
+            SlotComponentType.ParrotVariant => 78,
+            SlotComponentType.TropicalFishPattern => 79,
+            SlotComponentType.TropicalFishBaseColor => 80,
+            SlotComponentType.TropicalFishPatternColor => 81,
+            SlotComponentType.MooshroomVariant => 82,
+            SlotComponentType.RabbitVariant => 83,
+            SlotComponentType.PigVariant => 84,
+            SlotComponentType.CowVariant => 85,
+            SlotComponentType.ChickenVariant => 86,
+            SlotComponentType.FrogVariant => 87,
+            SlotComponentType.HorseVariant => 88,
+            SlotComponentType.PaintingVariant => 89,
+            SlotComponentType.LlamaVariant => 90,
+            SlotComponentType.AxolotlVariant => 91,
+            SlotComponentType.CatVariant => 92,
+            SlotComponentType.CatCollar => 93,
+            SlotComponentType.SheepColor => 94,
+            SlotComponentType.ShulkerColor => 95,
+            _ => throw new InvalidOperationException($"Unknown SlotComponentType {value} for protocol {protocolVersion}.")
+        };
+    }
+}

--- a/src/McProtoNet.Protocol/Types/UntrustedSlot.cs
+++ b/src/McProtoNet.Protocol/Types/UntrustedSlot.cs
@@ -1,0 +1,91 @@
+using McProtoNet.Protocol.Attributes;
+using McProtoNet.Serialization;
+
+namespace McProtoNet.Protocol;
+
+[ProtocolSupport(770, MinecraftVersion.LatestProtocol)]
+public sealed partial record UntrustedSlot(Slot Slot, IReadOnlyList<UntrustedSlotComponent> Components)
+{
+    public static UntrustedSlot Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<UntrustedSlot>(protocolVersion);
+        int itemCount = reader.ReadVarInt();
+        if (itemCount == 0)
+        {
+            return new UntrustedSlot(new Slot { ItemCount = 0 }, Array.Empty<UntrustedSlotComponent>());
+        }
+
+        int itemId = reader.ReadVarInt();
+        int addedCount = reader.ReadVarInt();
+        int removedCount = reader.ReadVarInt();
+        UntrustedSlotComponent[] components = ReadComponents(ref reader, protocolVersion, addedCount);
+        SlotComponentType[] removed = ReadRemovedComponents(ref reader, protocolVersion, removedCount);
+
+        var slot = new Slot
+        {
+            ItemId = itemId,
+            ItemCount = itemCount,
+            RemovedComponents = removed
+        };
+
+        return new UntrustedSlot(slot, components);
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<UntrustedSlot>(protocolVersion);
+        int count = Slot.ItemCount.GetValueOrDefault(0);
+        writer.WriteVarInt(count);
+        if (count == 0)
+        {
+            return;
+        }
+
+        writer.WriteVarInt(Slot.ItemId ?? 0);
+        writer.WriteVarInt(Components.Count);
+        writer.WriteVarInt(Slot.RemovedComponents?.Count ?? 0);
+        for (int i = 0; i < Components.Count; i++)
+        {
+            Components[i].Write(ref writer, protocolVersion);
+        }
+        if (Slot.RemovedComponents is not null)
+        {
+            foreach (var removed in Slot.RemovedComponents)
+            {
+                removed.Write(ref writer, protocolVersion);
+            }
+        }
+    }
+
+    private static UntrustedSlotComponent[] ReadComponents(ref MinecraftPrimitiveReader reader, int protocolVersion, int count)
+    {
+        if (count == 0)
+        {
+            return Array.Empty<UntrustedSlotComponent>();
+        }
+
+        var components = new UntrustedSlotComponent[count];
+        for (int i = 0; i < count; i++)
+        {
+            components[i] = UntrustedSlotComponent.Read(ref reader, protocolVersion);
+        }
+
+        return components;
+    }
+
+    private static SlotComponentType[] ReadRemovedComponents(ref MinecraftPrimitiveReader reader, int protocolVersion, int count)
+    {
+        if (count == 0)
+        {
+            return Array.Empty<SlotComponentType>();
+        }
+
+        var components = new SlotComponentType[count];
+        for (int i = 0; i < count; i++)
+        {
+            components[i] = SlotComponentTypeExtensions.Read(ref reader, protocolVersion);
+        }
+
+        return components;
+    }
+}

--- a/src/McProtoNet.Protocol/Types/UntrustedSlotComponent.cs
+++ b/src/McProtoNet.Protocol/Types/UntrustedSlotComponent.cs
@@ -1,0 +1,23 @@
+using McProtoNet.Protocol.Attributes;
+using McProtoNet.Serialization;
+
+namespace McProtoNet.Protocol;
+
+[ProtocolSupport(770, MinecraftVersion.LatestProtocol)]
+public sealed partial record UntrustedSlotComponent(SlotComponentType Type, ByteArray Data)
+{
+    public static UntrustedSlotComponent Read(ref MinecraftPrimitiveReader reader, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<UntrustedSlotComponent>(protocolVersion);
+        var type = SlotComponentTypeExtensions.Read(ref reader, protocolVersion);
+        var data = ByteArray.Read(ref reader, protocolVersion);
+        return new UntrustedSlotComponent(type, data);
+    }
+
+    public void Write(ref MinecraftPrimitiveWriter writer, int protocolVersion)
+    {
+        ThrowHelper.ThrowIfProtocolNotSupported<UntrustedSlotComponent>(protocolVersion);
+        Type.Write(ref writer, protocolVersion);
+        Data.Write(ref writer, protocolVersion);
+    }
+}


### PR DESCRIPTION
### Motivation

- Model the evolving Slot data family as a single semantic core and support the component-based decomposition described in the type JSON history.  
- Represent `SlotComponent` as a discriminated union that unifies multiple historical component shapes into semantic variants.  
- Provide serialization orchestration that delegates primitive and native behaviours to the protocol extension layer while preserving version-dependent wire logic in `Read*/Write*`.  
- Provide wrappers/modifiers (`UntrustedSlot`, `HashedSlot`) and placeholders for non-slot dependencies to allow compilation and future implementation.

### Description

- Added a core `Slot` class with unified semantic fields (`ItemId`, `ItemCount`, `Nbt`, `Components`, `RemovedComponents`) and version-aware `Read`/`Write` methods that call `ThrowIfProtocolNotSupported<T>()` and branch on `protocolVersion` for wire formats.  
- Implemented `SlotComponent` as a `Dunet`-style discriminated union with one case per component id, plus `Read`/`Write` orchestration that uses a `SlotComponentType` enum and versioned mapping helpers to encode/decode the component id then serialize the case payloads using `ProtocolSerializationExtensions` primitives.  
- Added `SlotComponentType` enum and `SlotComponentTypeExtensions` with versioned `Read`/`Write` mapping functions to reflect id → name changes across protocol ranges.  
- Added wrapper/modifier types: `UntrustedSlot`, `UntrustedSlotComponent`, and `HashedSlot` that wrap `Slot` semantics and reuse `Slot`/`SlotComponent` for payloads; all provide `Read`/`Write` methods accepting `protocolVersion`.  
- Introduced helper shims and placeholders: `RegistryEntryHolder<T>` wrapper, `ProtocolSerializationExtensions` stubs for `registryEntryHolder` read/write, new anonymous NBT helpers (`ReadAnonymousNbtTag`, `WriteAnonymousNbtTag`), and `WritePosition` helper; plus many minimal placeholder dependency types (e.g. `ArmorTrimMaterial`, `ItemBlockPredicate`, `ItemSoundHolder`, etc.) whose `Read`/`Write` throw `NotImplementedException` per rules.  
- Serialization strictly delegates primitive wire operations to `ProtocolSerializationExtensions` and uses small helper array/read-write helpers inside the `SlotComponent` implementation; `Read*/Write*` signatures include `protocolVersion` and invoke protocol-range checks as required.

### Testing

- Automated tests were not executed for this change set.  
- No CI or build verification was run as part of this change (only code generation and local commits were performed).  
- Placeholder native serializers (`registryEntryHolder`, byte-array, and many dependency types) intentionally throw `NotImplementedException` and must be implemented in the serialization layer before end-to-end serialization tests can pass.  
- Manual compilation / test runs were not requested or performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953f58a397083258da9c97125ef7fc0)